### PR TITLE
added a script to revert the farmos version to 1.5

### DIFF
--- a/docker/revertTo1-5.sh
+++ b/docker/revertTo1-5.sh
@@ -1,0 +1,18 @@
+#This script will revert the farmos version to 1.5
+#The container needs to be running
+
+
+curLoc=$(pwd)
+name=$(basename $curLoc)
+
+
+echo "Removing previous files"
+sudo docker exec -it ${name}_www_1 rm -R /var/www/html/
+
+
+echo "Downloading 1.5"
+sudo docker exec -it ${name}_www_1 curl -SL "http://ftp.drupal.org/files/projects/farm-7.x-1.5-core.tar.gz" -o /tmp/farm-7.x-1.5-core.tar.gz 
+
+echo "Unzipping"
+sudo docker exec -it ${name}_www_1  tar -xvzf /tmp/farm-7.x-1.5-core.tar.gz -C /var/www/html/ --strip-components=1
+sudo docker exec -it ${name}_www_1  chown -R www-data:www-data /var/www/html


### PR DESCRIPTION
__Pull Request Description__

I added a script that will revert the farmos version to 1.5.  It seems a bit of a clunky way to do it, but this is what Mike suggested.


---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
