### PR TITLE
Fix the link to Issue Tracker in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ The project [Issue Tracker] contains tickets describing known issues with the pr
 
 To participate by Gardening follow the [Install Directions] to get FarmData2 up and running. Then visit the [Issue Tracker] and find something of interest to verify, enhance or clarify.  Add a comment to the ticket with what you find.
 
-[Issue Tracker]: https://www.contributor-covenant.org
+[Issue Tracker]: https://github.com/DickinsonCollege/FarmData2/issues
 
 #### Bug Reports ###
 


### PR DESCRIPTION
__Pull Request Description__

Fix the link to the Issue Tracker in file CONTRIBUTING.md (closes #33)

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
