### PR TITLE
adding link to Clone

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ The basic steps for working with GitHub Flow is as follows:
 
   * Go to the [FarmData2 Repository] (the _upstream_)
   * Fork the _upstream_ repository to your GitHub (the _origin_).
-  * Clone the _origin_ repository to your local machine.
+  * [Clone] the _origin_ repository to your local machine.
   * Set the  _upstream_ remote for your local repository to point to the _upstream_ repository.
   * Create a _feature branch_ from the _main_ branch your local machine.
   * Make the edits to the documentation or the code in your _feature branch_.
@@ -70,5 +70,6 @@ The basic steps for working with GitHub Flow is as follows:
   * Push your _feature branch_ to the _origin_.
   * Make a Pull Request for your _feature branch_ to the _upstream_.  
 
+[Clone]: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/cloning-a-repository
 [FarmData2 Repository]: https://github.com/DickinsonCollege/FarmData2
 [Creating a commit with multiple authors]: https://docs.github.com/en/free-pro-team@latest/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors


### PR DESCRIPTION
__Pull Request Description__

This will add a link to a github webpage that shows a user how to clone a project. This is helpful so that a new contributor can have better info on how to contribute. This link will be close to the end of the page, and will be located with the word "Clone".

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
