### PR TITLE
Added fix for slow retina display on mac.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,6 +22,7 @@ The following are some recommendations for setting up a development platform usi
   - When creating your virtual machine:
     - Allocate a virtual disk of at least 20GB.
     - Set the Video Memory to 128 MB.
+   - __MacOS:__ If you are running VirtualBox on MacOS using a machine with a retina display the performance can be quite sluggish. [Launching VirtualBox in Low Resolution Mode](https://forums.virtualbox.org/viewtopic.php?f=8&t=90446&start=75#p470879) will resolve this issue.
 
 #### Prerequisites ####
 


### PR DESCRIPTION
__Pull Request Description__

Running VirtualBox on Retina display on mac can cause it to be very slow.  Added to INSTALL documentation a link to how to run VirtualBox in low resolution mode, which solves the problem.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
