### PR TITLE
Fixed theia container name

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,7 +28,6 @@ services:
     environment:
       XDEBUG_CONFIG: remote_host=172.17.0.1
 
-
   phpmyadmin:
     depends_on:
       - db
@@ -56,7 +55,7 @@ services:
       HOST_GID: ${HOST_GID}
       HOST_USER: ${HOST_USER}
       HOST_GROUP: ${HOST_GROUP}
-    container_name: theiaide
+    container_name: fd2_theiaide
     user: ${HOST_USER}
     volumes:
      - ..:/home/${HOST_USER}/FarmData2


### PR DESCRIPTION
__Pull Request Description__

Fixed the image name of the Theia container that is built so that it is fd2_theiaide to match the others.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
