### PR TITLE
Added clear cache to fd2-up.bash

### DIFF
--- a/docker/fd2-up.bash
+++ b/docker/fd2-up.bash
@@ -8,3 +8,5 @@ export HOST_GROUP=$(id -ng)
 docker rm $(docker ps -a -q -f name=fd2_) > /dev/null 2>&1
 
 docker-compose up -d
+
+docker exec -it fd2_farmdata2 drush cc all


### PR DESCRIPTION
__Pull Request Description__

Added a step in the fd2-up.bash script that clears the drupal cache.  This will ensure that anytime a new image is produced that all of the modules are reloaded.  Issues with out this would be rare, but this prevents them.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
