### PR TITLE
Removed line with undefined variable.

### DIFF
--- a/docker/farmOS/restws.entity.inc
+++ b/docker/farmOS/restws.entity.inc
@@ -410,7 +410,8 @@ class RestWSEntityResourceController implements RestWSQueryResourceControllerInt
 
     // The bundle key is a special case.
     if ($property === 'bundle') {
-      $operation = 'entityCondition' . $operation;
+      //$operation = 'entityCondition' . $operation;
+      $operation = 'entityCondition' 
       $query->$operation($property, $value);
     }
     // If field is not set, then the filter is a property and we can extract


### PR DESCRIPTION
__Pull Request Description__

The $operation variable was undefined here so commented it out to remove that error.  This seems to be working for now.  But it may be that this causes other errors in FarmOS that I haven't seen yet.  What needs to happen is to go back to the original version of the restws.entity.inc file and see where the $operation variable was getting set and then see if a more complete fix can be made. 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
