### PR TITLE
password inititalization

### DIFF
--- a/docker/updatepassword.sh
+++ b/docker/updatepassword.sh
@@ -1,0 +1,20 @@
+
+newDrupalAdmin=qwer
+newFarmdata2db=asdfx
+newMariadbRoot=zxcv
+
+
+
+
+rm temp.php 
+docker exec -it fd2_farmdata2 sed "s/'password' => '.*'/'password' => '$newFarmdata2db'/" /var/www/html/sites/default/settings.php >> temp.php
+docker exec -it fd2_farmdata2 rm /var/www/html/sites/default/settings2.php
+docker cp temp.php fd2_farmdata2:/var/www/html/sites/default/settings2.php
+docker exec -it fd2_farmdata2 cp /var/www/html/sites/default/settings2.php /var/www/html/sites/default/settings.php
+docker exec -it fd2_mariadb mysql -u root -pfarm -e "alter user 'farmdata2db'@'%' identified by '$newFarmdata2db'"
+
+
+docker exec -it fd2_mariadb mysql -u root -pfarm -e "alter user 'root'@'localhost' identified by '$newMariadbRoot'"
+docker exec -it fd2_mariadb mysql -u root -pfarm -e "alter user 'root'@'%' identified by '$newMariadbRoot'"
+
+docker exec -it fd2_farmdata2 drush upwd --password=$newDrupalAdmin admin


### PR DESCRIPTION
__Pull Request Description__

This script allows a user to change the passwords of the drupal admin account, the farmdata2db account in the database, and the root account of the database.  It also changes the settings file to allow drupal to continue to talk to the database with the new password.  

Closes #42 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
