### PR TITLE
Ignored files docker./logo created by mount into farmOS container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 docker/db/*
+docker/logo/tmp/**
+docker/logo/.htaccess
 
 .theia/logs/*
 .theia/workspace-storage/*


### PR DESCRIPTION
__Pull Request Description__

Mounting docker/logo into the farmOS container creates some additional files in the directory that do not need to be part of the repo.  So added those to the .gitignore.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
