### PR TITLE
Reordered BarnKit tabs

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/fd2_barn_kit.module
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/fd2_barn_kit.module
@@ -50,19 +50,10 @@ function fd2_barn_kit_menu() {
     'weight' => -10,
   );
 
-  $items['farm/fd2-barn-kit/transplanting'] = array(
-    'title' => 'Transplanting',
-    'type' => MENU_LOCAL_TASK,
-    'page callback' => 'fd2_barn_kit_view',
-    'page arguments' => array('transplanting.html'),
-    'access arguments' => array('view fd2 barn kit'),
-    'weight' => 100,
-  );
-  
   $items['farm/fd2-barn-kit/info'] = array(
     'title' => 'Info',
     'type' => MENU_DEFAULT_LOCAL_TASK,
-    'weight' => -10,
+    'weight' => -100,
   );
   
   $items['farm/fd2-barn-kit/harvestReport'] = array(
@@ -83,15 +74,24 @@ function fd2_barn_kit_menu() {
     'weight' => -80,
   );
 
-!
   $items['farm/fd2-barn-kit/traySeedingReport'] = array(
     'title' => 'Tray Seeding Report',
     'page callback' => 'fd2_barn_kit_view',
     'page arguments' => array('traySeedingReport.html'),
     'access arguments' => array('view fd2 barn kit'),
     'type' => MENU_LOCAL_TASK,
-    'weight' => -10,
+    'weight' => -70,
   );
+
+  $items['farm/fd2-barn-kit/transplanting'] = array(
+    'title' => 'Transplanting',
+    'type' => MENU_LOCAL_TASK,
+    'page callback' => 'fd2_barn_kit_view',
+    'page arguments' => array('transplanting.html'),
+    'access arguments' => array('view fd2 barn kit'),
+    'weight' => -60,
+  );
+
   return $items;
 };
 


### PR DESCRIPTION
__Pull Request Description__

Reorders the reporting tabs under the BarnKit tabs so that info is on the left and the others appear in a defined order after that.  This was done by setting the weights given  that lower (more negative weights) appear further to the left.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
