### PR TITLE
Connects Cypress TestRunner to Docker network 

### DIFF
--- a/farmdata2_modules/test_runner.bash
+++ b/farmdata2_modules/test_runner.bash
@@ -42,5 +42,6 @@ docker run -it \
   --rm \
   -e DISPLAY=$DISPLAY \
   --name fd2_cypress \
+  --network docker_default \
   --entrypoint npx \
   cypress:$FD_VER cypress $TEST_CMD --project .


### PR DESCRIPTION

__Pull Request Description__

Connected the Cypress test runner to the docker network so it can talk to FarmData in test code without going through the FarmData2 user interface.  For example, to unit test scripts that make api calls, or to seed the database with data for a test, or to remove data added to the database by a test. 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
