### PR TITLE
Added axios to the cypress test runner docker image.

### DIFF
--- a/docker/cypress/Dockerfile
+++ b/docker/cypress/Dockerfile
@@ -57,9 +57,10 @@ RUN npm install -g vue@2.6.13 @vue/cli@4.5.13
 # Make a vue project into which the fd2 testing will be mounted
 RUN vue create -d fd2test --packageManager npm
 
-# Add cypress compontent testing to the Vue project.
+# Add cypress compontent testing and axios to the Vue project.
 WORKDIR fd2test
 RUN npm install --save-dev cypress@7.4.0 @cypress/vue@2.2.3 @cypress/webpack-dev-server@1.3.1 webpack-dev-server@3.11.2
+RUN npm install --save-dev axios
 
 # should print Cypress version
 # plus Electron and bundled Node versions

--- a/farmdata2_modules/test_runner.bash
+++ b/farmdata2_modules/test_runner.bash
@@ -5,7 +5,7 @@ xhost + > /dev/null
 # If Dockerfile in docker/cypress is changed update
 # the version number here to the next increment so that 
 # it will rebuild for anyone using it.
-FD_VER=fd2.2
+FD_VER=fd2.3
 
 if [ $# -ne 1 ] || [ "$1" != "e2e" -a "$1" != "ct" ]
 then


### PR DESCRIPTION
__Pull Request Description__

To run tests in cypress that use axios it was necessary to have axios installed in the container using npm so that it was available to the tests.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
