### PR TITLE
Fetch all pages

### DIFF
--- a/farmdata2_modules/cypress.json
+++ b/farmdata2_modules/cypress.json
@@ -4,6 +4,7 @@
     "testFiles": "**/*.spec.js",
     "video": false,
     "screenshotOnRunFailure": false,
+    "chromeWebSecurity": false,
     "component": {
       "componentFolder": "farmdata2_modules",
        "testFiles": "**/*.spec.comp.js"

--- a/farmdata2_modules/fd2_tabs/resources/FarmOSAPI.js
+++ b/farmdata2_modules/fd2_tabs/resources/FarmOSAPI.js
@@ -1,0 +1,45 @@
+try {
+    FarmData2
+}
+catch {
+    axios = require('axios')
+}
+
+// A collection of functions for interacting with the 
+// farmOS API.  All pages should use these so that any
+// updates apply to all pages.
+
+function getAllPages(url, arr) {
+    // Concatenates the contents of the list property from 
+    // all pages of a multipage response into arr
+    return new Promise((resolve, reject) => {
+        
+        axios.get(url)
+        .then(function(response) {
+            return JSON.parse(response.data)
+        })
+        .then(function(data) {
+            arr.push.apply(arr,data.list)
+
+            if (!data.hasOwnProperty('next')) {
+                resolve()
+            }
+            else {
+                getAllPages(data.next, arr)
+                .then(function() {
+                    resolve()
+                })
+            }
+        })
+        .catch(function(error) {
+            reject(error)
+        })
+    })
+}
+
+try {
+    module.exports = {
+        getAllPages: getAllPages
+    }
+}
+catch(err) {}

--- a/farmdata2_modules/fd2_tabs/resources/FarmOSAPI.js
+++ b/farmdata2_modules/fd2_tabs/resources/FarmOSAPI.js
@@ -10,17 +10,22 @@ catch {
 // updates apply to all pages.
 
 function getAllPages(url, arr) {
-    // Concatenates the contents of the list property from 
-    // all pages of a multipage response into arr
+    // Retrieves all pages of a multipage response.
+    // Usage:   
+    //    let result = []
+    //    getAllPages(url, result)
+    //
+    // The result array will be filled with the elements from
+    // response.data.list from all of the pages.  Each page of
+    // responses is added to the array as it is retrieved.
+    
     return new Promise((resolve, reject) => {
-        
         axios.get(url)
         .then(function(response) {
-            return JSON.parse(response.data)
+            return response.data
         })
         .then(function(data) {
             arr.push.apply(arr,data.list)
-
             if (!data.hasOwnProperty('next')) {
                 resolve()
             }

--- a/farmdata2_modules/fd2_tabs/resources/FarmOSAPI.spec.js
+++ b/farmdata2_modules/fd2_tabs/resources/FarmOSAPI.spec.js
@@ -11,7 +11,7 @@ describe('API Request Function', () => {
     })
 
     it('completes the request and puts the data into the passed array', () => {
-        testArray = apiRequest(testURL)
+        getAllPages(testURL, testArray)
         expect(testArray).to.have.length.of.at.least(1)
     })
 })

--- a/farmdata2_modules/fd2_tabs/resources/FarmOSAPI.spec.js
+++ b/farmdata2_modules/fd2_tabs/resources/FarmOSAPI.spec.js
@@ -1,17 +1,50 @@
-import { apiRequest } from './APIRequestFunction.js';
+import { getAllPages } from './FarmOSAPI.js';
 
 describe('API Request Function', () => {
-    var testURL
     var testArray
     
     beforeEach(() => {
         cy.login('restws1', 'farmdata2')
-        testURL = 'http://fd2_farmdata2/log.json?type=farm_seeding'
         testArray = []
     })
 
-    it('completes the request and puts the data into the passed array', () => {
-        getAllPages(testURL, testArray)
-        expect(testArray).to.have.length.of.at.least(1)
+    /*
+    it.only('Test on a request with one page.', () => {
+        // Note: For some reason the following does not work. It should
+        // intercept all requests to log but it does not match any.
+        // Maybe a cypress bug?  Maybe a future version will fix it?
+
+        cy.intercept('GET','/log?').as('onlyone')
+        getAllPages('/log?type=farm_seeding&id[lt]=1500', testArray)
+
+        cy.wait('@onlyone').should(() => {
+            cy.wrap(testArray).should('have.length.equal',100)
+        })
+    })
+    */
+
+    it('Test on a request with multiple pages', () => {
+        // Note: For some reasson the following did not work to intecept
+        // the original request.
+        // cy.intercept('GET','/log?type=farm_seeding').as('original')
+        // Maybe a cypress bug?  Maybe a future version will fix it?
+
+        cy.intercept('GET','/log?type=farm_seeding&page=1').as('second')
+        cy.intercept('GET','/log?type=farm_seeding&page=2').as('third')
+        
+        getAllPages('/log?type=farm_seeding', testArray)
+
+        cy.wait('@second').should(() => {
+            // Just by getting here we know the second page was requested.
+
+            // Check that data made it into testArray.
+            // Note: depending on timing this may not run until after any
+            // subsequent calls.
+            cy.wrap(testArray).should('have.length.gt',100)
+        })
+
+        cy.wait('@third').should(() => {
+            cy.wrap(testArray).should('have.length.gt',200)
+        })
     })
 })

--- a/farmdata2_modules/fd2_tabs/resources/farmOSAPI.spec.js
+++ b/farmdata2_modules/fd2_tabs/resources/farmOSAPI.spec.js
@@ -1,0 +1,17 @@
+import { apiRequest } from './APIRequestFunction.js';
+
+describe('API Request Function', () => {
+    var testURL
+    var testArray
+    
+    beforeEach(() => {
+        cy.login('restws1', 'farmdata2')
+        testURL = 'http://fd2_farmdata2/log.json?type=farm_seeding'
+        testArray = []
+    })
+
+    it('completes the request and puts the data into the passed array', () => {
+        testArray = apiRequest(testURL)
+        expect(testArray).to.have.length.of.at.least(1)
+    })
+})


### PR DESCRIPTION
__Pull Request Description__

Adds the getAllPages function in the farmdata2_modules/resources/farmOSAPI.js file.  Given a URL and an array, the function fills the array with the values from the response.data.list from every page in a multipage response.

@Co-authored-by: josiecook <cookjo@dickinson.edu>
---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
