### PR TITLE
Removed .only on tests

### DIFF
--- a/farmdata2_modules/fd2_tabs/resources/FarmOSAPI.spec.js
+++ b/farmdata2_modules/fd2_tabs/resources/FarmOSAPI.spec.js
@@ -34,7 +34,7 @@ describe('API Request Function', () => {
             })
         })
 
-        it.only('Test on a request with multiple pages', () => {
+        it('Test on a request with multiple pages', () => {
             cy.intercept("GET",/log\?type=farm_seeding$/).as('first')
             cy.intercept("GET","/log?type=farm_seeding&page=1").as('second')
             cy.intercept("GET","/log?type=farm_seeding&page=2").as('third')
@@ -88,7 +88,7 @@ describe('API Request Function', () => {
         })
     })
 
-    context.only('deleteLog API request function', () => {
+    context('deleteLog API request function', () => {
         it('deletes a log based on log ID', () => {
             getSessionToken()
             .then(function(token) {


### PR DESCRIPTION
__Pull Request Description__

Several tests in the FarmOSAPI.spec.js contained .only flags so not all tests would run.  This removed those so all tests now run.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
