### PR TITLE
Fixed getAllPages test using get and proper alias

### DIFF
--- a/farmdata2_modules/fd2_tabs/resources/FarmOSAPI.spec.js
+++ b/farmdata2_modules/fd2_tabs/resources/FarmOSAPI.spec.js
@@ -34,7 +34,7 @@ describe('API Request Function', () => {
             })
         })
 
-        it.only('Test on a request with multiple pages', () => {
+        it('Test on a request with multiple pages', () => {
             cy.intercept("GET",/log\?type=farm_seeding$/).as('first')
             cy.intercept("GET","/log?type=farm_seeding&page=1").as('second')
             cy.intercept("GET","/log?type=farm_seeding&page=2").as('third')
@@ -44,7 +44,7 @@ describe('API Request Function', () => {
             let thirdCalls=0
 
             cy.wait(1)
-            .then(() => {
+            .then(function() {
                 cy.wait('@first').should(() => {
                     cy.wrap(testArray).should('have.length.gt',0)
                     firstCalls++
@@ -54,8 +54,6 @@ describe('API Request Function', () => {
                     // Just by getting here we know the second page was requested.
 
                     // Check that data made it into testArray.
-                    // Note: depending on timing this may not run until after any
-                    // subsequent calls.
                     cy.wrap(testArray).should('have.length.gt',100)
                     secondCalls++
                 })
@@ -65,8 +63,8 @@ describe('API Request Function', () => {
                     thirdCalls++
                 })
 
-                cy.wrap(getAllPages("/log?type=farm_seeding", testArray)).as('getAll')
-                cy.wait('@getAll)').then(() => {
+                cy.wrap(getAllPages("/log?type=farm_seeding", testArray)).as('all')
+                cy.get('@all').should(() => {
                     expect(firstCalls).to.equal(1)
                     expect(secondCalls).to.equal(1)
                     expect(thirdCalls).to.equal(1)
@@ -88,7 +86,7 @@ describe('API Request Function', () => {
         })
     })
 
-    context.only('deleteLog API request function', () => {
+    context('deleteLog API request function', () => {
         it('deletes a log based on log ID', () => {
             getSessionToken()
             .then(function(token) {
@@ -116,7 +114,7 @@ describe('API Request Function', () => {
                 .then(function() {
                     cy.wrap(deleteLog(this.logID, token))
                     .as('delete')
-                    cy.get('@delete').should(function(response) {
+                    cy.get('@delete').should((response) => {
                         expect(response.status).to.equal(200)
                     })
                 }) 


### PR DESCRIPTION
__Pull Request Description__

The getAllPages test for multiple pages used a wait where it should have been a get and also included an extraneous ) in the wait for the alias.  A few other small changes were made.  function's were used only where there is a need for the this object in the test, otherwise the () => {} notation was used.  Also removed some stray .only's in the test spec so that all tests will run.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
