### PR TITLE
Updated script to set farm name and slogan

### DIFF
--- a/docker/sampleDB/buildSampleDB.bash
+++ b/docker/sampleDB/buildSampleDB.bash
@@ -17,6 +17,11 @@ tar -xjf db.empty.tar.bz2
 cd sampleDB
 echo "Switched to empty db image."
 
+echo "Setting farm info..."
+docker exec -it fd2_farmdata2 drush vset site_name "Sample Farm"
+docker exec -it fd2_farmdata2 drush vset site_slogan "Farm with sample data for development and testing."
+echo "Set."
+
 echo "Enabling restws basic authentication..."
 docker exec -it fd2_farmdata2 drush en restws_basic_auth -y
 echo "restws basic authentication enabled."


### PR DESCRIPTION
__Pull Request Description__

The script that builds the sample database (docker/buildSampleDB.bash) now also sets the farm name to "Sample" and the slogan to indicate that it is a sample farm for testing and development.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
