### PR TITLE
Updates the Names of Crops (e.g. ONION-SPRING)

### DIFF
--- a/docker/sampleDB/README.md
+++ b/docker/sampleDB/README.md
@@ -117,7 +117,7 @@ GET http://localhost/log.json?type=farm_seeding"
 
 Notes:
 - The `log_category` attribute can be used to distinguish between logs for Direct Seedings and logs for Tray Seedings.
-- The `data` attribute will contain an object that provides the `tid` of the crop that was seeded (e.g. `{ cropID: 115 }`).  This can be used to get the crop name wihtout retrieving the Planting Asset.
+- The `data` attribute will contain an object that provides the `crop_tid` of the crop that was seeded (e.g. `{ crop_tid: 115 }`).  This can be used to get the crop name wihtout retrieving the Planting Asset.
 
 ### Planting Assets ###
 

--- a/docker/sampleDB/README.md
+++ b/docker/sampleDB/README.md
@@ -69,7 +69,7 @@ The terms for the Farm Crop Families vocabulary can be accessed with the request
 GET http://localhost/taxonomy_term.json?bundle=farm_crop_families"
 ```
 
-The Farm Crops/Varities Vocabulary define all of the crops that appear in the FarmData2 database.  Each crop is assigned to one of the crop categories defined in the Farm Crop Families vocabulay.  Crops can also be parent or child-crops. For example LETTUCE is a parent crop to ROMAINE and GREEN, and conversely they are child crops to LETTUCE.
+The Farm Crops/Varities Vocabulary define all of the crops that appear in the FarmData2 database.  Each crop is assigned to one of the crop categories defined in the Farm Crop Families vocabulay.  Crops can also be parent or child-crops. For example LETTUCE is a parent crop to LETTUCE-ROMAINE and LETTUCE-GREEN, and conversely they are child crops to LETTUCE. 
 
 The terms for the Farm Crops vocabulary can be accessed with the request:
 ```
@@ -117,6 +117,7 @@ GET http://localhost/log.json?type=farm_seeding"
 
 Notes:
 - The `log_category` attribute can be used to distinguish between logs for Direct Seedings and logs for Tray Seedings.
+- The `data` attribute will contain an object that provides the `tid` of the crop that was seeded (e.g. `{ cropID: 115 }`).  This can be used to get the crop name wihtout retrieving the Planting Asset.
 
 ### Planting Assets ###
 

--- a/docker/sampleDB/addCrops.py
+++ b/docker/sampleDB/addCrops.py
@@ -45,10 +45,11 @@ def main():
                     #"weight": cropWeight,   # Omit to use alphabetical order in farmOS
                 }
                 parentCropID = addVocabTerm(crop)
+                parentCropName = row[1]
                 cropWeight+=1
             else:
                 crop = {
-                    "name": row[2],
+                    "name": parentCropName + "-" + row[2],
                     "vocabulary": cropVocabID,
                     "parent": [{
                         "id": parentCropID,

--- a/docker/sampleDB/addDirectSeedings.py
+++ b/docker/sampleDB/addDirectSeedings.py
@@ -183,7 +183,7 @@ def addSeeding(row, plantingID, seedingTypeID):
         }],
         "lot_number": row[15],
         "data": json.dumps({ 
-            "cropID": cropMap[row[2]] 
+            "crop_tid": cropMap[row[2]] 
         })
     }
 

--- a/docker/sampleDB/addDirectSeedings.py
+++ b/docker/sampleDB/addDirectSeedings.py
@@ -181,7 +181,10 @@ def addSeeding(row, plantingID, seedingTypeID):
             "id": userMap[row[11]],
             "resource": "user"
         }],
-        "lot_number": row[15]
+        "lot_number": row[15],
+        "data": json.dumps({ 
+            "cropID": cropMap[row[2]] 
+        })
     }
 
     return addLog(seeding)

--- a/docker/sampleDB/addTraySeedings.py
+++ b/docker/sampleDB/addTraySeedings.py
@@ -211,7 +211,10 @@ def addSeeding(row, plantingID, seedingTypeID):
             "id": userMap[row[1]],
             "resource": "user"
         }],
-        "lot_number": row[7]
+        "lot_number": row[7],
+        "data": json.dumps({ 
+            "cropID": cropMap[row[3]] 
+        })
     }
 
     return addLog(seeding)

--- a/docker/sampleDB/addTraySeedings.py
+++ b/docker/sampleDB/addTraySeedings.py
@@ -213,7 +213,7 @@ def addSeeding(row, plantingID, seedingTypeID):
         }],
         "lot_number": row[7],
         "data": json.dumps({ 
-            "cropID": cropMap[row[3]] 
+            "crop_tid": cropMap[row[3]] 
         })
     }
 

--- a/docker/sampleDB/buildSampleDB.bash
+++ b/docker/sampleDB/buildSampleDB.bash
@@ -48,7 +48,6 @@ source ./addPeople.bash
   ./addDirectSeedings.py
   ./addTraySeedings.py
   
-
 echo "Compressing the sample database..."
 cd ..
 rm -f db.sample.tar.bz2

--- a/docker/sampleDB/buildSampleDB.bash
+++ b/docker/sampleDB/buildSampleDB.bash
@@ -38,9 +38,6 @@ source ./addPeople.bash
 # Create the vocabularies
   # Add the farm areas (fields, greenhouses, beds)
   ./addAreas.py
-
-  exit()
-  
   # Add the crop families and crops.
   ./addCrops.py
   # Add the units used for quantities

--- a/docker/sampleDB/buildSampleDB.bash
+++ b/docker/sampleDB/buildSampleDB.bash
@@ -38,6 +38,9 @@ source ./addPeople.bash
 # Create the vocabularies
   # Add the farm areas (fields, greenhouses, beds)
   ./addAreas.py
+
+  exit()
+  
   # Add the crop families and crops.
   ./addCrops.py
   # Add the units used for quantities

--- a/docker/sampleDB/sampleData/crops.csv
+++ b/docker/sampleDB/sampleData/crops.csv
@@ -13,14 +13,19 @@
 #   and links it to the Farm Crop Family that it appears under.
 #
 # A line beginning with two commas:
-#   Creates a term in the Farm Crop/Varieties vocabularly 
-#   and sets its parent to the crop that it appears under.
-#
+#   Creates a term in the Farm Crop/Varieties vocabularly with
+#   the name being PARENT-CHILD (e.g. ONION-SPRING)
+#   and sets its parent to the crop that it appears under 
+#   (i.e. ONION is the parent of ONION-SPRING)
+# 
+# While this may seem strange to prepend the parent name, the issue
+# that arises otherwise is there are duplicate names in the vocabulary
+# (e.g. BEANS-DRY, CORN-DRY)
+# 
 # Crop families appear in farmOS in the oder listed in this file.
 # Crops appear in farmOS in alphabetical order in their families or overall.
 #
-# Anything following a # on a line is a considered a comment.
-# Thus, names and descriptions cannot contain #
+# Any line starting with # is a comment.
 # Blank Lines are ignored.
 
 Field/Forageable

--- a/docker/sampleDB/utils.py
+++ b/docker/sampleDB/utils.py
@@ -214,11 +214,6 @@ def getCropMap():
 
     for crop in allCrops:
         name = crop['name']
-
-        if len(crop['parent']) != 0:
-            parent = crop['parent'][0]['name']
-            name = parent + "-" + name
-
         cropMap[name] = crop['tid']
 
     return cropMap


### PR DESCRIPTION
__Pull Request Description__

There were duplicate crop names (e.g. DRY was both under BEANS and CORN).  This created problems mapping from crop name to cropID.  So converted to using compound crop named (e.g. BEANS-DRY and CORN-DRY).  

Also added the cropID to the data field of the plantings to make it possible to find the crop vocabulary term without fetching the Planting.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
