### PR TITLE
Translate 0000-00-00 Transplantings

### DIFF
--- a/docker/sampleDB/addTransplantings.py
+++ b/docker/sampleDB/addTransplantings.py
@@ -88,9 +88,11 @@ def addPlanting(row):
     # there wasn't a record for it in the seeding data so the seeding date was
     # hand modified in the sample data to be 0000-00-00 (see above)
     # In practice those with seeding dates may have been ones where there 
-    # was a planting but it was not recoreded.  there seems to be no
+    # was a planting but it was not recoreded.  There seems to be no
     # real harm here in treating them like the other 0000-00-00's for the sample data.
-    plantingDate = '0000-00-00'
+
+    # In all cases use the transplanting date as the date of the planting.
+    plantingDate = row[8]
 
     planting = {
         "name": plantingDate + " " + row[3] + " " + row[2],


### PR DESCRIPTION
__Pull Request Description__

A number of transplantings in the sample data from FarmData have a seeding date of 0000-00-00 indicating that there was no seeding to connect to.  This could be because the plants arrived in a tray or because a seeding was just never created.  This update uses the transplanting date to create a planting for the transplanting.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
