### PR TITLE
Removed apt update from Cypress Dockerfile

### DIFF
--- a/docker/cypress/Dockerfile
+++ b/docker/cypress/Dockerfile
@@ -7,7 +7,9 @@
 FROM cypress/browsers:node14.16.0-chrome89-ff77
 
 # Update the dependencies to get the latest and greatest (and safest!) packages.
-RUN apt update && apt upgrade -y
+# Updating here breaks things if packages move on.  As this is purely a
+# dev tool it's better to stay fixed and not break.
+# RUN apt-get update && apt-get upgrade -y
 
 # avoid too many progress messages
 # https://github.com/cypress-io/cypress/issues/1243


### PR DESCRIPTION
As apt packages were modified by others this began generating errors.
Becasue this is a dev only container we'll leave everything fixed
at the versions in the base container to prevent future errors. Everything
can be moved to newer versions all at once when necessary.

__Pull Request Description__

<Add description>

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
