### PR TITLE
Spinner reappear

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -29,7 +29,7 @@
                 <br>
             </div>
 
-            <div class="loader center-block" v-if="stillLoading"></div>
+            <div data-cy="loader" class="loader center-block" v-if="stillLoading"></div>
 
             <div v-if="seedingLogs.length != 0">
                 <br>

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -107,6 +107,8 @@
                     getAllPages(link, this.seedingLogs).then(() => {
                         this.stillLoading = false
                     })
+                    //Should set stillLoading to its intitial true state when finished
+                    this.stillLoading = true
                 },
                 cropChange(selectedCrop){
                     this.selectedCrop = selectedCrop

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
@@ -56,7 +56,7 @@ describe('Testing for the seeding report page', () => {
 
         
     })
-    context.only('can see spinner at appropriate times', () => {
+    context('can see spinner at appropriate times', () => {
         before(() => {
             cy.login('manager1', 'farmdata2')
             cy.visit('/farm/fd2-barn-kit/seedingReport')

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
@@ -83,22 +83,6 @@ describe('Testing for the seeding report page', () => {
                 cy.get('[data-cy=loader]').should('not.exist')
             }) 
         })
-        it.only('spinner remains before API return', () => {
-            cy.get('[data-cy=start-date-select]')
-                .type('2019-01-01')
-            cy.get('[data-cy=end-date-select]')
-                .type('2019-05-15')
-            cy.get('[data-cy=generate-rpt-btn]').click()
-            cy.get('[data-cy=report-table]', { timeout: 20000 }).find('tr').its('length').then(length =>{
-                expect(length).to.equal(101)
-                cy.get('[data-cy=loader]').should('exist')
-            })
-            cy.wait(10000)
-            cy.get('[data-cy=report-table]').find('tr').its('length').then(length =>{
-                expect(length).to.equal(263)
-                cy.get('[data-cy=loader]').should('not.exist')
-            })
-        })
         it('spinner reappears after changing values and clicking again', () => {
             cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
@@ -60,25 +60,50 @@ describe('Testing for the seeding report page', () => {
         before(() => {
             cy.login('manager1', 'farmdata2')
             cy.visit('/farm/fd2-barn-kit/seedingReport')
+
+        })
+
+        it('show spinner after input', () => {
             cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')
             cy.get('[data-cy=end-date-select]')
                 .type('2019-03-01')
             cy.get('[data-cy=generate-rpt-btn]').click()
-        })
-
-        it('show spinner after input', () => {
             cy.get('[data-cy=loader]').should('be.visible')
         })
-        it('spinner dissappears after API return', () => {
-            cy.get('[data-cy=report-table]', { timeout: 10000 }).should('be.visible')
-            cy.get('[data-cy=loader]').should('not.exist')
+
+        it('spinner dissappears after whole response returns 1 page', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-02-01')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+            cy.get('[data-cy=report-table]', { timeout: 20000 }).find('tr').its('length').then(length =>{
+                expect(length).to.equal(3)
+                cy.get('[data-cy=loader]').should('not.exist')
+            }) 
+        })
+        it.only('spinner remains before API return', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-05-15')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+            cy.get('[data-cy=report-table]', { timeout: 20000 }).find('tr').its('length').then(length =>{
+                expect(length).to.equal(101)
+                cy.get('[data-cy=loader]').should('exist')
+            })
+            cy.wait(10000)
+            cy.get('[data-cy=report-table]').find('tr').its('length').then(length =>{
+                expect(length).to.equal(263)
+                cy.get('[data-cy=loader]').should('not.exist')
+            })
         })
         it('spinner reappears after changing values and clicking again', () => {
             cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')
             cy.get('[data-cy=end-date-select]')
-                .type('2019-03-02')
+                .type('2019-03-03')
             cy.get('[data-cy=generate-rpt-btn]').click()
             cy.get('[data-cy=loader]').should('be.visible')
         })

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
@@ -56,6 +56,33 @@ describe('Testing for the seeding report page', () => {
 
         
     })
+    context.only('can see spinner at appropriate times', () => {
+        before(() => {
+            cy.login('manager1', 'farmdata2')
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+        })
+
+        it('show spinner after input', () => {
+            cy.get('[data-cy=loader]').should('be.visible')
+        })
+        it('spinner dissappears after API return', () => {
+            cy.get('[data-cy=report-table]', { timeout: 10000 }).should('be.visible')
+            cy.get('[data-cy=loader]').should('not.exist')
+        })
+        it('spinner reappears after changing values and clicking again', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-02')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+            cy.get('[data-cy=loader]').should('be.visible')
+        })
+    })
 
     context('displays the right information in the table', () => {
         before(() => {
@@ -461,7 +488,7 @@ describe('Testing for the seeding report page', () => {
         })
     })
 
-    context.only('date picker and filter behavior', () => {
+    context('date picker and filter behavior', () => {
         before(() => {
             cy.login('manager1', 'farmdata2')
             cy.visit('/farm/fd2-barn-kit/seedingReport')


### PR DESCRIPTION
__Pull Request Description__

The loading spinner that appears when the "Generate Report" button is clicked, now reappears when it is clicked more times. 

Closes #272 
Closes #270 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
