### PR TITLE
Summary Table Timing and No Log Messages

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -29,7 +29,7 @@
                 <br>
             </div>
 
-            <div class="loader center-block" v-if="stillLoading"></div>
+            <div data-cy="loader" class="loader center-block" v-if="stillLoading"></div>
 
             <div v-if="seedingLogs.length != 0">
                 <br>
@@ -107,6 +107,8 @@
                     getAllPages(link, this.seedingLogs).then(() => {
                         this.stillLoading = false
                     })
+                    //Should set stillLoading to its intitial true state when finished
+                    this.stillLoading = true
                 },
                 cropChange(selectedCrop){
                     this.selectedCrop = selectedCrop

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -31,7 +31,7 @@
 
             <div data-cy="loader" class="loader center-block" v-if="stillLoading"></div>
 
-            <div v-if="seedingLogs.length != 0">
+            <div v-if="!stillLoading && seedingLogs.length != 0">
                 <br>
 
                 <div style="display: flex; width: 100%;">

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -63,7 +63,7 @@
                 </div>
             </div>
             <div v-if="!stillLoading && seedingLogs.length == 0">
-                <div class="box" style="  
+                <div class="box" data-cy="no-logs-message" style="  
                     border: 5px solid #d62a17;
                     background-color: white;
                     padding: 20px;

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -33,23 +33,32 @@
 
             <div v-if="!stillLoading && seedingLogs.length != 0">
                 <br>
-
                 <div style="display: flex; width: 100%;">
                     <fieldset data-cy="direct-summary" class="center-block panel panel-default" style="width: 50%;" v-if="!(selectedSeeding=='Tray Seedings')">
                         <legend class="panel-heading" style="background-color: #d62a17; color: white;">Direct Seeding Summary</legend>
-                        <p style="margin-left: 5%;"> Total Row/Bed Planted: <b>{{ totalRowBed }}</b></p>
-                        <p style="margin-left: 5%;"> Total Row Feet Planted: <b>{{ totalRowFeet }}</b></p>
-                        <p style="margin-left: 5%;">Total Bed Feet Planted: <b>{{ totalBedFeet }}</b></p>
-                        <p style="margin-left: 5%;">Total Hours Worked: <b>{{ totalDirectSeedingHours }}</b></p>
-                        <p style="margin-left: 5%;">Total Bed Feet per Hour: <b>{{ totalBedFeetPerHour }}</b></p>
-                        <p style="margin-left: 5%;">Total Row Feet per Hour: <b>{{ totalRowFeetPerHour }}</b></p>
+                        <div v-if="getTableOneType == 'Tray Seedings'">
+                            <p style="margin-left: 5%;"> There are no Direct Seeding logs with these parameters</p>
+                        </div>
+                        <div v-else>
+                            <p style="margin-left: 5%;"> Total Row/Bed Planted: <b>{{ totalRowBed }}</b></p>
+                            <p style="margin-left: 5%;"> Total Row Feet Planted: <b>{{ totalRowFeet }}</b></p>
+                            <p style="margin-left: 5%;">Total Bed Feet Planted: <b>{{ totalBedFeet }}</b></p>
+                            <p style="margin-left: 5%;">Total Hours Worked: <b>{{ totalDirectSeedingHours }}</b></p>
+                            <p style="margin-left: 5%;">Total Bed Feet per Hour: <b>{{ totalBedFeetPerHour }}</b></p>
+                            <p style="margin-left: 5%;">Total Row Feet per Hour: <b>{{ totalRowFeetPerHour }}</b></p>
+                        </div>
                     </fieldset>
                     <fieldset data-cy="tray-summary" class="center-block panel panel-default" style="width: 47%;" v-if="!(selectedSeeding=='Direct Seedings')">
                         <legend class="panel-heading" style="background-color: #d62a17; color: white;">Tray Seeding Summary</legend>
-                        <p style="margin-left: 5%;">Total Number of Tray Seeds Planted: <b>{{ traySeedsPlanted }}</b></p>
-                        <p style="margin-left: 5%;">Total Number of Trays: <b>{{ totalNumTrays }}</b></p>
-                        <p style="margin-left: 5%;">Total Hours Worked: <b>{{ totalTraySeedingHours }}</b></p>
-                        <p style="margin-left: 5%;">Average Seeds Planted per Hour: <b>{{ aveSeedsPerHour }}</b></p>
+                        <div v-if="getTableOneType == 'Direct Seedings'">
+                            <p style="margin-left: 5%;"> There are no Tray Seeding logs with these parameters</p>
+                        </div>
+                        <div v-else>
+                            <p style="margin-left: 5%;">Total Number of Tray Seeds Planted: <b>{{ traySeedsPlanted }}</b></p>
+                            <p style="margin-left: 5%;">Total Number of Trays: <b>{{ totalNumTrays }}</b></p>
+                            <p style="margin-left: 5%;">Total Hours Worked: <b>{{ totalTraySeedingHours }}</b></p>
+                            <p style="margin-left: 5%;">Average Seeds Planted per Hour: <b>{{ aveSeedsPerHour }}</b></p>
+                        </div>
                     </fieldset>
                 </div>
             </div>
@@ -340,6 +349,17 @@
                         }
                     })
                     return rows
+                },
+                getTableOneType(){
+                    let currentType = this.tableRows[0].data[3]
+                    for (i = 0 ; i < this.tableRows.length ; i ++){
+                        if (this.tableRows[i].data[3] == currentType){
+                            currentType = this.tableRows[i].data[3]
+                        }else{
+                            return false
+                        }
+                    }
+                    return currentType
                 },
                 /**
                  * returns a sorted array of all the crops in the current logs. If area or type of seeding does not equal 'All' then the array will only contain crops that have the selected area and/or type of seeding

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
@@ -93,6 +93,40 @@ describe('Testing for the seeding report page', () => {
         })
     })
 
+    context('shows message when only one type', () => {
+        before(() => {
+            cy.login('manager1', 'farmdata2')
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+
+        })
+
+        it('show both tables with two types', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2020-05-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2020-06-01')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+
+        })
+
+        it('show direct seeding message when only tray seeding', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-05-06')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-05-10')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+
+        })
+        it('show tray seeding message when only direct seeding', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-05-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-05-04')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+        })
+
+    })
+
     context('displays the right information in the table', () => {
         before(() => {
             cy.login('manager1', 'farmdata2')

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
@@ -93,7 +93,7 @@ describe('Testing for the seeding report page', () => {
         })
     })
 
-        context.only('can see No Logs message at appropriate times', () => {
+        context('can see No Logs message at appropriate times', () => {
         before(() => {
             cy.login('manager1', 'farmdata2')
             cy.visit('/farm/fd2-barn-kit/seedingReport')
@@ -125,6 +125,32 @@ describe('Testing for the seeding report page', () => {
             cy.get('[data-cy=generate-rpt-btn]').click()
             cy.get('[data-cy=no-logs-message]', {timeout: 20000}).should('be.visible')
         })
+    })
+    context('can see summary tables at appropriate times', () => {
+        before(() => {
+            cy.login('manager1', 'farmdata2')
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+
+        })
+        it('does not immediately display summary tables', () => {
+                cy.get('[data-cy=tray-summary]').should('not.exist')
+                cy.get('[data-cy=direct-summary]').should('not.exist')
+        })
+        it('shows summary tables after table is fully loaded', () => {
+
+            cy.get('[data-cy=report-table]', { timeout: 20000 }).find('tr').its('length').then(length =>{
+                expect(length).to.equal(35)
+                cy.get('[data-cy=tray-summary]').should('be.visible')
+                cy.get('[data-cy=direct-summary]').should('be.visible')
+            }) 
+        })
+
+
     })
 
     context('shows message when only one type', () => {

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
@@ -56,6 +56,42 @@ describe('Testing for the seeding report page', () => {
 
         
     })
+    context('can see spinner at appropriate times', () => {
+        before(() => {
+            cy.login('manager1', 'farmdata2')
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+
+        })
+
+        it('show spinner after input', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+            cy.get('[data-cy=loader]').should('be.visible')
+        })
+
+        it('spinner dissappears after whole response returns 1 page', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-02-01')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+            cy.get('[data-cy=report-table]', { timeout: 20000 }).find('tr').its('length').then(length =>{
+                expect(length).to.equal(3)
+                cy.get('[data-cy=loader]').should('not.exist')
+            }) 
+        })
+        it('spinner reappears after changing values and clicking again', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-03')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+            cy.get('[data-cy=loader]').should('be.visible')
+        })
+    })
 
     context('displays the right information in the table', () => {
         before(() => {
@@ -461,7 +497,7 @@ describe('Testing for the seeding report page', () => {
         })
     })
 
-    context.only('date picker and filter behavior', () => {
+    context('date picker and filter behavior', () => {
         before(() => {
             cy.login('manager1', 'farmdata2')
             cy.visit('/farm/fd2-barn-kit/seedingReport')

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
@@ -97,32 +97,43 @@ describe('Testing for the seeding report page', () => {
         before(() => {
             cy.login('manager1', 'farmdata2')
             cy.visit('/farm/fd2-barn-kit/seedingReport')
-
-        })
-
-        it('show both tables with two types', () => {
             cy.get('[data-cy=start-date-select]')
                 .type('2020-05-01')
             cy.get('[data-cy=end-date-select]')
                 .type('2020-06-01')
             cy.get('[data-cy=generate-rpt-btn]').click()
-
         })
+
 
         it('show direct seeding message when only tray seeding', () => {
-            cy.get('[data-cy=start-date-select]')
-                .type('2019-05-06')
-            cy.get('[data-cy=end-date-select]')
-                .type('2019-05-10')
-            cy.get('[data-cy=generate-rpt-btn]').click()
+            cy.get('[data-cy=dropdown-input]', {timeout: 20000}).then(($dropdowns) => {
+                cy.get($dropdowns[1]).should('exist')
+                    .select('ENDIVE')
+                    .should('have.value', 'ENDIVE')
+            })
+            cy.get('[data-cy=direct-summary').should('have.text', 'Direct Seeding Summary  There are no Direct Seeding logs with these parameters')
+        })
+
+        it('show tray seeding message when only direct seeding', () => {
+            cy.get('[data-cy=dropdown-input]', {timeout: 20000}).then(($dropdowns) => {
+                cy.get($dropdowns[1]).should('exist')
+                    .select('CORN-SWEET')
+                    .should('have.value', 'CORN-SWEET')
+            })
+            cy.get('[data-cy=tray-summary').should('have.text', 'Tray Seeding Summary  There are no Tray Seeding logs with these parameters')
+        })
+
+        it('show both tables with two types', () => {
+            cy.get('[data-cy=direct-summary', {timeout: 20000}).should('be.visible')
+            cy.get('[data-cy=tray-summary]').should('be.visible')
 
         })
-        it('show tray seeding message when only direct seeding', () => {
-            cy.get('[data-cy=start-date-select]')
-                .type('2019-05-01')
-            cy.get('[data-cy=end-date-select]')
-                .type('2019-05-04')
-            cy.get('[data-cy=generate-rpt-btn]').click()
+
+        it('show one tables with one type', () => {
+            cy.get('[data-cy=dropdown-input]', {timeout: 20000}).first().select('Direct Seedings').should('have.value', 'Direct Seedings')
+            cy.get('[data-cy=direct-summary').should('be.visible')
+            cy.get('[data-cy=tray-summary]').should('not.exist')
+
         })
 
     })

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
@@ -93,6 +93,40 @@ describe('Testing for the seeding report page', () => {
         })
     })
 
+        context.only('can see No Logs message at appropriate times', () => {
+        before(() => {
+            cy.login('manager1', 'farmdata2')
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+
+        })
+
+        it('does not show No Logs message after input with logs', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+            cy.get('[data-cy=no-logs-message]').should('not.exist')
+        })
+
+        it('shows No Logs message after input without logs', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2021-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2021-03-01')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+            cy.get('[data-cy=no-logs-message]', {timeout: 20000}).should('be.visible')
+        })
+        it('shows No Logs message after input without logs reinput', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2030-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2030-03-01')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+            cy.get('[data-cy=no-logs-message]', {timeout: 20000}).should('be.visible')
+        })
+    })
+
     context('shows message when only one type', () => {
         before(() => {
             cy.login('manager1', 'farmdata2')


### PR DESCRIPTION
__Pull Request Description__

- Summary Tables now show up after the report table is completely loaded to avoid confusion. Issue #284 
- When filters leave only Direct or Tray Seeding logs in the table, a message is shown in the opposite table to notify the user of this. Issue #259
- When a date range is selected with no logs, a message is displayed instead of the table. Issue #258

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
