### PR TITLE
No Default Label For Drop Down Component

### DIFF
--- a/farmdata2_modules/fd2_tabs/resources/DropdownWithAllComponent.js
+++ b/farmdata2_modules/fd2_tabs/resources/DropdownWithAllComponent.js
@@ -3,7 +3,7 @@
  */ 
 let DropdownWithAllComponent = {
     template: `<div data-cy="dropdown-component">
-            <label for="dropdownOptions"><slot>Select: </slot></label>
+            <label for="dropdownOptions"><slot> </slot></label>
             <select id="dropdownOptions" v-model="selectedOption" data-cy="dropdown-input" @change="selectionChanged">
                 <option v-for="singleOption in fullDropdown" data-cy="single-option">{{ singleOption }}</option>
             </select>


### PR DESCRIPTION
__Pull Request Description__

The default label "Select:" for the DropDownWithAllComponent is no longer present. 

Closed: #292 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
