### PR TITLE
New date change report timing

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -29,7 +29,7 @@
                 <br>
             </div>
 
-            <div class="loader center-block" v-if="stillLoading"></div>
+            <div data-cy="loader" class="loader center-block" v-if="stillLoading"></div>
 
             <div v-if="seedingLogs.length != 0">
                 <br>
@@ -107,6 +107,8 @@
                     getAllPages(link, this.seedingLogs).then(() => {
                         this.stillLoading = false
                     })
+                    //Should set stillLoading to its intitial true state when finished
+                    this.stillLoading = true
                 },
                 cropChange(selectedCrop){
                     this.selectedCrop = selectedCrop

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -4,7 +4,9 @@
         <fieldset :disabled="rowBeingEdited" class="panel panel-default center-block" style="width: 50%;">
             <legend class="panel-heading" style="background-color: #d62a17; color: white;">Set Dates</legend>
             <div style="display: flex;width: 100%; padding: 7px">
-                <date-range-selection data-cy="date-range-selection" class="center-block"  @start-date-changed='startDateChange' @end-date-changed='endDateChange' :default-start-date=startDate :default-end-date=endDate></date-range-selection>
+                <date-range-selection data-cy="date-range-selection" class="center-block"  @start-date-changed='startDateChange' @end-date-changed='endDateChange' 
+                @hide='hide'
+                :default-start-date=startDate :default-end-date=endDate></date-range-selection>
 
                 <button data-cy="generate-rpt-btn" class="btn center-block btn-primary" v-if='!reportVisible' @click='seedingLogRequestWithDates'>Generate Report</button>
             </div>
@@ -111,15 +113,20 @@
                 rowBeingEdited: false
             },
             methods: {
-                startDateChange(selectedDate){
-                    this.startDate = selectedDate
+                hide(){
+                    console.log('ya clicked')
                     this.reportVisible = false
                     this.seedingLogs = []
                 },
+                startDateChange(selectedDate){
+                    this.startDate = selectedDate
+                    //this.reportVisible = false
+                    //this.seedingLogs = []
+                },
                 endDateChange(selectedDate){
                     this.endDate = selectedDate
-                    this.reportVisible = false
-                    this.seedingLogs = []
+                    //this.reportVisible = false
+                    //this.seedingLogs = []
                 },
                 seedingLogRequestWithDates(){
                     this.reportVisible = true

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -5,7 +5,7 @@
             <legend class="panel-heading" style="background-color: #d62a17; color: white;">Set Dates</legend>
             <div style="display: flex;width: 100%; padding: 7px">
                 <date-range-selection data-cy="date-range-selection" class="center-block"  @start-date-changed='startDateChange' @end-date-changed='endDateChange' 
-                @hide='hide'
+                @click='hide'
                 :default-start-date=startDate :default-end-date=endDate></date-range-selection>
 
                 <button data-cy="generate-rpt-btn" class="btn center-block btn-primary" v-if='!reportVisible' @click='seedingLogRequestWithDates'>Generate Report</button>
@@ -114,7 +114,6 @@
             },
             methods: {
                 hide(){
-                    console.log('ya clicked')
                     this.reportVisible = false
                     this.seedingLogs = []
                 },

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
@@ -56,6 +56,42 @@ describe('Testing for the seeding report page', () => {
 
         
     })
+    context('can see spinner at appropriate times', () => {
+        before(() => {
+            cy.login('manager1', 'farmdata2')
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+
+        })
+
+        it('show spinner after input', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+            cy.get('[data-cy=loader]').should('be.visible')
+        })
+
+        it('spinner dissappears after whole response returns 1 page', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-02-01')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+            cy.get('[data-cy=report-table]', { timeout: 20000 }).find('tr').its('length').then(length =>{
+                expect(length).to.equal(3)
+                cy.get('[data-cy=loader]').should('not.exist')
+            }) 
+        })
+        it('spinner reappears after changing values and clicking again', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-03')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+            cy.get('[data-cy=loader]').should('be.visible')
+        })
+    })
 
     context('displays the right information in the table', () => {
         before(() => {
@@ -461,7 +497,7 @@ describe('Testing for the seeding report page', () => {
         })
     })
 
-    context.only('date picker and filter behavior', () => {
+    context('date picker and filter behavior', () => {
         before(() => {
             cy.login('manager1', 'farmdata2')
             cy.visit('/farm/fd2-barn-kit/seedingReport')

--- a/farmdata2_modules/fd2_tabs/resources/DateRangeSelectionComponent.js
+++ b/farmdata2_modules/fd2_tabs/resources/DateRangeSelectionComponent.js
@@ -8,10 +8,12 @@ catch(err) {
 
 let DateRangeSelectionComponent = {
     template: `<div>
-                <date-selection data-cy="start-date-select" :defaultDate="defaultStartDate" :latestDate="latestStartDate" @date-changed="startDateChange">
+                <date-selection data-cy="start-date-select" :defaultDate="defaultStartDate" :latestDate="latestStartDate" @date-changed="startDateChange" 
+                @hide="hide">
                     Start Date:
                 </date-selection>
-                <date-selection data-cy="end-date-select" :defaultDate="defaultEndDate" :earliestDate="earliestEndDate" @date-changed="endDateChange">
+                <date-selection data-cy="end-date-select" :defaultDate="defaultEndDate" :earliestDate="earliestEndDate" @date-changed="endDateChange"
+                @hide="hide">
                     End Date:
                 </date-selection>
             </div>
@@ -36,6 +38,9 @@ let DateRangeSelectionComponent = {
         }
     },
     methods: {
+        hide(){
+            this.$emit('hide')
+        },
         startDateChange(selectedDate){
             this.earliestEndDate = selectedDate
             this.$emit('start-date-changed', selectedDate)

--- a/farmdata2_modules/fd2_tabs/resources/DateRangeSelectionComponent.js
+++ b/farmdata2_modules/fd2_tabs/resources/DateRangeSelectionComponent.js
@@ -9,11 +9,11 @@ catch(err) {
 let DateRangeSelectionComponent = {
     template: `<div>
                 <date-selection data-cy="start-date-select" :defaultDate="defaultStartDate" :latestDate="latestStartDate" @date-changed="startDateChange" 
-                @hide="hide">
+                @click="click">
                     Start Date:
                 </date-selection>
                 <date-selection data-cy="end-date-select" :defaultDate="defaultEndDate" :earliestDate="earliestEndDate" @date-changed="endDateChange"
-                @hide="hide">
+                @click="click">
                     End Date:
                 </date-selection>
             </div>
@@ -38,8 +38,8 @@ let DateRangeSelectionComponent = {
         }
     },
     methods: {
-        hide(){
-            this.$emit('hide')
+        click(){
+            this.$emit('click')
         },
         startDateChange(selectedDate){
             this.earliestEndDate = selectedDate

--- a/farmdata2_modules/fd2_tabs/resources/DateRangeSelectionComponent.spec.comp.js
+++ b/farmdata2_modules/fd2_tabs/resources/DateRangeSelectionComponent.spec.comp.js
@@ -49,6 +49,16 @@ describe('date range selection component', () => {
                  })
     })
 
+    it('emits on click', () => {
+        const spy = cy.spy()
+        Cypress.vue.$on('click', spy)
+        cy.get('[data-cy=start-date-select]')
+            .children().click()
+                .then(() => {
+                    expect(spy).to.be.called
+                 })
+    })
+
     it('emits the new slected end date', () => {
         const spy = cy.spy()
         Cypress.vue.$on('end-date-changed', spy)

--- a/farmdata2_modules/fd2_tabs/resources/DateSelectionComponent.js
+++ b/farmdata2_modules/fd2_tabs/resources/DateSelectionComponent.js
@@ -1,7 +1,7 @@
 let DateSelectionComponent = {
     template: `<div>
             <slot></slot>
-            <input data-cy="date-select" type="date" :min="earliestDate" :max="latestDate" id="date" v-model="selectedDate" @focusout="checkBounds">
+            <input data-cy="date-select" type="date" :min="earliestDate" :max="latestDate" id="date" v-model="selectedDate" @click="hide" @focusout="checkBounds">
             </div>`,
     props: {
         defaultDate: {
@@ -21,6 +21,9 @@ let DateSelectionComponent = {
         } 
     },
     methods: {
+        hide(){
+            this.$emit('hide')
+        },
         checkBounds() {
             if (this.selectedDate > this.latestDate) {
                 this.selectedDate = this.latestDate;

--- a/farmdata2_modules/fd2_tabs/resources/DateSelectionComponent.js
+++ b/farmdata2_modules/fd2_tabs/resources/DateSelectionComponent.js
@@ -1,7 +1,7 @@
 let DateSelectionComponent = {
     template: `<div>
             <slot></slot>
-            <input data-cy="date-select" type="date" :min="earliestDate" :max="latestDate" id="date" v-model="selectedDate" @click="hide" @focusout="checkBounds">
+            <input data-cy="date-select" type="date" :min="earliestDate" :max="latestDate" id="date" v-model="selectedDate" @click="click" @focusout="checkBounds">
             </div>`,
     props: {
         defaultDate: {
@@ -21,8 +21,8 @@ let DateSelectionComponent = {
         } 
     },
     methods: {
-        hide(){
-            this.$emit('hide')
+        click(){
+            this.$emit('click')
         },
         checkBounds() {
             if (this.selectedDate > this.latestDate) {

--- a/farmdata2_modules/fd2_tabs/resources/DateSelectionComponent.spec.comp.js
+++ b/farmdata2_modules/fd2_tabs/resources/DateSelectionComponent.spec.comp.js
@@ -38,8 +38,19 @@ describe('date selection component', () => {
             .blur()
             .should('have.value', '2021-01-01')
     })
+    
+    it('emits on click', () => {
+        const spy = cy.spy()
+        Cypress.vue.$on('click', spy)
+        cy.get('[data-cy=date-select]')
+            .click()
+                .then(() => {
+                    expect(spy).to.be.called
+                 })
+    })
 
-    it('emits date after input type date is blured', () => {
+
+    it('emits date after input type date is blurred', () => {
         const spy = cy.spy()
         Cypress.vue.$on('date-changed', spy)
         cy.get('[data-cy=date-select]')


### PR DESCRIPTION
__Pull Request Description__

This should resolve #274.

It should:
- change the timing of the report disappearing to when the input is clicked 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
