### PR TITLE
Moved theia docker image to farmdata2 dockerhub

### DIFF
--- a/docker/theia/Dockerfile
+++ b/docker/theia/Dockerfile
@@ -1,4 +1,4 @@
-FROM theiaide/theia:1.7.0
+FROM farmdata2/theia:1.7.0
 
 # NOTE: If changes are made here that require a new image
 # update the tag in docker-compose.yml for force the rebuild


### PR DESCRIPTION
__Pull Request Description__

The theiaide/theia:1.7.0 image was removed from theiaide on Docker Hub.  So a new account was created for farmdata2 and the theia:1.7.0 image was placed there.  This is a temporary solution and a more permanent solution should be found.  Most likely, farmdata2 should move to a VS Code container instead of theia.  That is a bigger move than can be done right now so this stop gap will suffice for now.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
