### PR TITLE
Removed missed line causing parse errors

### DIFF
--- a/farmdata2_modules/fd2_tabs/resources/CustomTableComponent.js
+++ b/farmdata2_modules/fd2_tabs/resources/CustomTableComponent.js
@@ -20,9 +20,9 @@ let CustomTableComponent = {
                     <td v-for="(item, ci) in row.data"
                     v-if="isVisible[ci]"
                     :data-cy="'td-r'+ri+'c'+ci">
-                        <div v-if="!(rowToEditIndex==ri) || inputType[ci].type == 'no input'"
+                        <div v-if="rowToEditIndex!=ri || inputType[ci].type == 'no input'"
                         :data-cy="'r'+ri+'c'+ci"
-                        v-html="item"></div>
+                        v-html='item'></div>
                                     
                         <textarea 
                         :data-cy="'text-input-r'+ri+'c'+ci"

--- a/farmdata2_modules/fd2_tabs/resources/CustomTableComponent.spec.comp.js
+++ b/farmdata2_modules/fd2_tabs/resources/CustomTableComponent.spec.comp.js
@@ -309,7 +309,7 @@ describe('custom table component', () => {
     context('with different input types', () => {
         let prop= {
             rows: [
-                { id: 10, data: ['static', 'edit', 3, 'Yes', '2020-01-01']}
+                { id: 10, data: ['fixed', 'edit', 3, 'Yes', '2020-01-01'] }
             ],
             headers: ['None', 'Text', 'Number', 'Dropdown', 'Date'],
             canEdit: true,
@@ -360,8 +360,6 @@ describe('custom table component', () => {
         })
 
         it('only allows you to pick numbers in a number input', () => {
-            prop.inputOptions[0] = {'type': 'number'}
-            
             cy.get('[data-cy=edit-button-r0]')
                 .click()
 


### PR DESCRIPTION
__Pull Request Description__

Missed a line when refactoring the tests that caused some parse errors trying to convert a string to a number.  Just removed that line.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
