### PR TITLE
Switched farmos image to farmdata2/farmos on DockerHub

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - db
     # If there are changes to the Dockerfile update the tag
     # here to force a new build when main is updated.
-    image: farmos:fd2.4
+    image: farmos:fd2.5
     build:
      context: ./farmOS
      dockerfile: Dockerfile

--- a/docker/farmOS/Dockerfile
+++ b/docker/farmOS/Dockerfile
@@ -1,4 +1,5 @@
-FROM farmos/farmos:dev
+FROM farmdata2/farmos
+#FROM farmos/farmos:dev
 
 # Builds a custom farmos image that includes the patch to the
 # restws module that allows for query parameters to use relational


### PR DESCRIPTION
__Pull Request Description__

farmos pushed a new dev instance of the farmos/farmos:dev image to dockerhub.  This broke the FarmData2 install process because of some changes contained in that image.  This patch freezes the farmos image being used by using our own copy of the farmos image that has been pushed to farmdata2/farmos on dockerhub.

The farmdata2/farmos image will be pulled and customized normally for new installs.  For existing installs the farmdata2/farmos image will be pulled and customized the first time a developer uses ./fd2-up.bash after pulling these changes from upstream main.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
