### PR TITLE
Eliminates duplicate areas in drop down

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
@@ -358,7 +358,7 @@
                 }else{
                     this.areaResponse = JSON.parse(localStorage.getItem('areas'))
                     getAllPages('/taxonomy_term.json?bundle=farm_areas').then((resp) => {
-                        this.areaResp = resp
+                        this.areaResponse = resp
                         localStorage.setItem('areas', JSON.stringify(resp))
                     })
                 }

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
@@ -358,6 +358,7 @@
                 }else{
                     this.areaResponse = JSON.parse(localStorage.getItem('areas'))
                     getAllPages('/taxonomy_term.json?bundle=farm_areas').then((resp) => {
+                        this.areaResp = resp
                         localStorage.setItem('areas', JSON.stringify(resp))
                     })
                 }

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
@@ -357,8 +357,8 @@
                     })
                 }else{
                     this.areaResponse = JSON.parse(localStorage.getItem('areas'))
-                    getAllPages('/taxonomy_term.json?bundle=farm_areas', this.areaResponse).then(() => {
-                        localStorage.setItem('areas', JSON.stringify(this.areaResponse))
+                    getAllPages('/taxonomy_term.json?bundle=farm_areas').then((resp) => {
+                        localStorage.setItem('areas', JSON.stringify(resp))
                     })
                 }
                 getSessionToken().then((response) => {


### PR DESCRIPTION
__Pull Request Description__

Fixes #460 

Modified the way the cached areas are updated.  When there were cached areas, an API call was made to check for updates and then the cached list was to be updated with the response. However, the response was being appended instead of replacing the existing list.  It now replaces it and updates the displayed list of areas also.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
