### PR TITLE
Issue260: delete total row/bed planted from summary section for direct seeding in the Seeding Report

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -42,7 +42,6 @@
                             <p style="margin-left: 5%;"> There are no Direct Seeding logs with these parameters</p>
                         </div>
                         <div v-else>
-                            <p style="margin-left: 5%;"> Total Row/Bed Planted: <b>{{ totalRowBed }}</b></p>
                             <p style="margin-left: 5%;"> Total Row Feet Planted: <b>{{ totalRowFeet }}</b></p>
                             <p style="margin-left: 5%;">Total Bed Feet Planted: <b>{{ totalBedFeet }}</b></p>
                             <p style="margin-left: 5%;">Total Hours Worked: <b>{{ totalDirectSeedingHours }}</b></p>
@@ -444,19 +443,6 @@
                     let seedingsType = new Set(seedingTypeArray)
                     let newSeedingTypeArray = Array.from(seedingsType)
                     return newSeedingTypeArray.sort()
-                },
-                /**
-                 * returns the total row/bed for the Direct Seedings
-                 */ 
-                totalRowBed(){
-                    let tableData = this.tableRows
-                    
-                    let sumRowBed = 0
-                    tableData.map(h => {
-                        sumRowBed = sumRowBed + parseInt(h.data[4])
-                    })
-
-                    return sumRowBed
                 },
                 /**
                  * returns the total row feet for Direct Seeding

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
@@ -9,8 +9,6 @@
                 <br>
                 <dropdown-with-all data-cy="crop-selection" :dropdown-list='cropArray' @selection-changed='setNewCrop'>Crop:<label style='color: #da4f3f'>*</label></dropdown-with-all>
                 <br>
-                <dropdown-with-all data-cy="area-selection" :dropdown-list='areaFilter' @selection-changed='setNewArea'>Area:<label style='color: #da4f3f'>*</label></dropdown-with-all>
-                <br>
                 <label>Comments: </label><textarea data-cy="comments" v-model='comments'></textarea>
             </div>
        </fieldset>
@@ -23,6 +21,7 @@
                 <p>Please Select Tray Seeding or Direct Seeding<label style='color: #da4f3f'>*</label></p>
             </div>
             <div v-if='(selectedSeedingType=="Tray Seedings")' style='padding: 12px;text-align:center;font-size: medium;'>
+                <dropdown-with-all data-cy="area-selection" :dropdown-list='areaFilter' @selection-changed='setNewArea'>Area:<label style='color: #da4f3f'>*</label></dropdown-with-all>
                 <label>Number of Trays Planted:<label style='color: #da4f3f'>*</label> </label><input data-cy='trays-planted' style='width: 75px;' type='number' v-model='numOfTrays'>
                 <br>
                 <label>Cells per Tray:<label style='color: #da4f3f'>*</label> </label><input data-cy='cells-tray' style='width: 75px;' type='number' v-model='numCellsPerTray'>
@@ -30,6 +29,7 @@
                 <label>Number of Seeds Planted:<label style='color: #da4f3f'>*</label> </label><input data-cy='seeds-planted' style='width: 75px;' type='number' v-model='numSeedsPlanted'>
             </div>
             <div v-if='(selectedSeedingType=="Direct Seedings")' style='padding: 12px;text-align:center;font-size: medium;'>
+                <dropdown-with-all data-cy="area-selection" :dropdown-list='areaFilter' @selection-changed='setNewArea'>Area:<label style='color: #da4f3f'>*</label></dropdown-with-all>
                 <label>Rows per Bed:<label style='color: #da4f3f'>*</label> </label><input data-cy='row-bed' style='width: 75px;' type='number' v-model='numRowBed'>
                 <div style='display: flex;text-align:center;padding-top: 25px;'>
                     <label>Number of Feet:<label style='color: #da4f3f'>*</label> </label><input data-cy='num-feet' style='width: 75px;' type='number' v-model='numFeet'><dropdown-with-all data-cy='unit-feet' :default-input='selectedFeetUnit' :dropdown-list='feetUnits' @selection-changed='setNewFeetUnit'>Units</dropdown-with-all>


### PR DESCRIPTION
__Pull Request Description__

Fixes #260 Deleted HTML component and the function under computed that correspond to the display and calculation of Total Bed/Row under the summary section for direct seeding. No changes were made to the cypress file as it did not include any total bed/row related test methods. 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
