### PR TITLE
Summary Table Edits

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -42,11 +42,11 @@
                             <p style="margin-left: 5%;"> There are no Direct Seeding logs with these parameters</p>
                         </div>
                         <div v-else>
-                            <p style="margin-left: 5%;"> Total Row Feet Planted: <b>{{ totalRowFeet }}</b></p>
+                            <p style="margin-left: 5%;">Total Row Feet Planted: <b>{{ totalRowFeet }}</b></p>
                             <p style="margin-left: 5%;">Total Bed Feet Planted: <b>{{ totalBedFeet }}</b></p>
-                            <p style="margin-left: 5%;">Total Hours Worked: <b>{{ totalDirectSeedingHours }}</b></p>
-                            <p style="margin-left: 5%;">Total Bed Feet per Hour: <b>{{ totalBedFeetPerHour }}</b></p>
-                            <p style="margin-left: 5%;">Total Row Feet per Hour: <b>{{ totalRowFeetPerHour }}</b></p>
+                            <p style="margin-left: 5%;">Total Hours: <b>{{ totalDirectSeedingHours }}</b></p>
+                            <p style="margin-left: 5%;">Average Row Feet/Hour: <b>{{ totalRowFeetPerHour }}</b></p>
+                            <p style="margin-left: 5%;">Average Bed Feet/Hour: <b>{{ totalBedFeetPerHour }}</b></p>
                         </div>
                     </fieldset>
                     <fieldset data-cy="tray-summary" class="center-block panel panel-default" style="width: 47%;" v-if="!(selectedSeeding=='Direct Seedings')">
@@ -55,10 +55,10 @@
                             <p style="margin-left: 5%;"> There are no Tray Seeding logs with these parameters</p>
                         </div>
                         <div v-else>
-                            <p style="margin-left: 5%;">Total Number of Tray Seeds Planted: <b>{{ traySeedsPlanted }}</b></p>
+                            <p style="margin-left: 5%;">Total Number of Seeds Planted: <b>{{ traySeedsPlanted }}</b></p>
                             <p style="margin-left: 5%;">Total Number of Trays: <b>{{ totalNumTrays }}</b></p>
-                            <p style="margin-left: 5%;">Total Hours Worked: <b>{{ totalTraySeedingHours }}</b></p>
-                            <p style="margin-left: 5%;">Average Seeds Planted per Hour: <b>{{ aveSeedsPerHour }}</b></p>
+                            <p style="margin-left: 5%;">Total Hours: <b>{{ totalTraySeedingHours }}</b></p>
+                            <p style="margin-left: 5%;">Average Seeds Planted/Hour: <b>{{ aveSeedsPerHour }}</b></p>
                         </div>
                     </fieldset>
                 </div>


### PR DESCRIPTION
__Pull Request Description__

Resolves #464. Removed unnecessary words from summary blocks. Removed 'per' and replaced it with a '/'. Made average rows/hour and bed/hour planted in direct seeding summary consistent with listing of rows and beds feet planted above.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
