### PR TITLE
Changed DropdownWithAllComponent from div to span element

### DIFF
--- a/farmdata2_modules/fd2_tabs/resources/DropdownWithAllComponent.js
+++ b/farmdata2_modules/fd2_tabs/resources/DropdownWithAllComponent.js
@@ -18,12 +18,12 @@
  * @vue-event {String} selection-changed - Emits the selected option when the option is changed. Note: This event is also emitted in the mounted lifecycle hook to signal the setting of the initial value.
  */ 
 let DropdownWithAllComponent = {
-    template: `<div data-cy="dropdown-component">
+    template: `<span data-cy="dropdown-component">
             <label for="dropdownOptions"><slot> </slot></label>
             <select id="dropdownOptions" v-model="selectedOption" data-cy="dropdown-input" @change="selectionChanged">
                 <option v-for="(singleOption,i) in fullDropdown" :data-cy="'option'+i">{{ singleOption }}</option>
             </select>
-        </div>`, 
+        </span>`, 
     props: {
         dropdownList: {
             type: Array,


### PR DESCRIPTION
__Pull Request Description__

The DropdownWithAllComponent Vue component was defined as a div element. This created difficulties with layouts where the dropdown was to be inline with other text or elements (e.g. in the Seeding Input form).  Changing this to a span allows the dropdown to be inline when desired.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
