### PR TITLE
Change div to span in components

### DIFF
--- a/farmdata2_modules/fd2_tabs/resources/DateRangeSelectionComponent.js
+++ b/farmdata2_modules/fd2_tabs/resources/DateRangeSelectionComponent.js
@@ -31,6 +31,7 @@ let DateRangeSelectionComponent = {
                 @click="click">
                     Start Date:
                 </date-selection>
+                <br>
                 <date-selection data-cy="end-date-select" :defaultDate="defaultEndDate" :earliestDate="earliestEndDate" @date-changed="endDateChange"
                 @click="click">
                     End Date:

--- a/farmdata2_modules/fd2_tabs/resources/DateSelectionComponent.js
+++ b/farmdata2_modules/fd2_tabs/resources/DateSelectionComponent.js
@@ -17,10 +17,10 @@
  * @vue-event {String} date-changed - Emits the selected date (YYYY-MM-DD) when a date is entered or chosen and the date input element loses focus.
  */ 
 let DateSelectionComponent = {
-    template: `<div>
+    template: `<span>
             <slot></slot>
             <input data-cy="date-select" type="date" :min="earliestDate" :max="latestDate" id="date" v-model="selectedDate" @click="click" @focusout="checkBounds">
-            </div>`,
+            </span>`,
     props: {
         defaultDate: {
             type: String,


### PR DESCRIPTION
__Pull Request Description__

Changed the DateSelectionComponent to be a span element instead of a div element.  Updated the DateRangeSelectionComponent to add a line break between the two DateSelectionComponents because they are now span elements. 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
