### PR TITLE
Time Reporting: Computes Hours Differently in Seeding Report

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -474,7 +474,7 @@
                  */ 
                 totalDirectSeedingHours(){
                     let tableData = this.tableRows
-                    let filteredTableData = tableData.filter((x) => x.data[3] === 'Direct Seedings')
+                    let filteredTableData = tableData.filter((x) => x.data[3] === 'Direct')
                     let sumHours = 0
                     filteredTableData.map(h => {
                         sumHours = sumHours + h.data[10]//*h.data[11])
@@ -524,7 +524,7 @@
                  */ 
                 totalTraySeedingHours(){
                     let tableData = this.tableRows
-                    let filteredTableData = tableData.filter((x) => x.data[3] === 'Tray Seedings')
+                    let filteredTableData = tableData.filter((x) => x.data[3] === 'Tray')
                     let sumHours = 0
                     filteredTableData.map(h => {
                         sumHours = sumHours + (parseFloat(h.data[10])*parseFloat(h.data[11]))

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -4,7 +4,7 @@
         <fieldset :disabled="rowBeingEdited" class="panel panel-default center-block" style="width: 50%;">
             <legend class="panel-heading" style="background-color: #d62a17; color: white;">Set Dates</legend>
             <div style="display: flex;width: 100%; padding: 7px">
-                <date-range-selection data-cy="date-range-selection" class="center-block"  @start-date-changed='startDateChange' @end-date-changed='endDateChange' 
+                <date-range-selection data-cy="date-range-selection" class="center-block" @start-date-changed='startDateChange' @end-date-changed='endDateChange' 
                 @click='hide'
                 :default-start-date='startDate' :default-end-date='endDate'></date-range-selection>
 
@@ -18,7 +18,7 @@
                 <fieldset :disabled="rowBeingEdited" data-cy="filters-panel" class="center-block panel panel-default" style="width: 75%;">
                     <legend class="panel-heading" style="background-color: #d62a17; color: white;">Filters</legend>
                     <div style="display: flex; width: 100%;">
-                        <dropdown-with-all data-cy="seeding-type-dropdown" class="center-block" :dropdown-list='seedingTypeList' includes-all default-input='All' @selection-changed='seedingChange'>Type Of Seeding:</dropdown-with-all>
+                        <dropdown-with-all data-cy="seeding-type-dropdown" class="center-block" :dropdown-list='seedingTypeList' includes-all default-input='All' @selection-changed='seedingChange'>Seeding Type:</dropdown-with-all>
                     
                         <dropdown-with-all data-cy="crop-dropdown" class="center-block" :dropdown-list='cropList' includes-all default-input='All' @selection-changed='cropChange'>Crop:</dropdown-with-all>
 
@@ -99,7 +99,7 @@
                 selectedArea: 'All',
                 selectedSeeding: 'All',
 
-                headers: ['date', 'crop', 'area', 'Tray/Direct', 'Row/Bed', 'Row Feet', 'Bed Feet', 'Tray Seeds', '# of Trays', 'Cells Per Tray', 'Hours', 'Num Workers','Varieties', 'Comments','User'],
+                headers: ['Date', 'Crop', 'Area', 'Seeding', 'Row/Bed', 'Row Feet', 'Bed Feet', 'Tray Seeds', '# of Trays', 'Cells Per Tray', 'Workers', 'Hours','Varieties', 'Comments','User'],
                 visibleColumns: [true, true, true, true, false, false, false, false, false, false, true, true, true, true, true],
 
                 idToCropMap: new Map(),
@@ -341,8 +341,8 @@
                                 traySeeds,
                                 numOfTrays,
                                 cellsPerTray,
-                                (Math.round(hours*100))/100,
                                 (Math.round(numWorkers*100))/100,
+                                (Math.round(hours*100))/100,
                                 h.lot_number,
                                 h.notes.value,
                                 $vm.idToUserMap.get(h.uid.id)

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -342,7 +342,7 @@
                                 numOfTrays,
                                 cellsPerTray,
                                 (Math.round(numWorkers*100))/100,
-                                (Math.round(hours*100))/100,
+                                (Math.round(hours*100))/100 * (Math.round(numWorkers*100))/100,
                                 h.lot_number,
                                 h.notes.value,
                                 $vm.idToUserMap.get(h.uid.id)


### PR DESCRIPTION
__Pull Request Description__

Resolves #476. This pull request changes how the Seeding Report calculates the hours column. Marcel's P.R actually changes the structure of  'Labor' in the Seeding Input Log to make this change more clear.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
