### PR TITLE
Made JSDoc install local rather than global

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,6 @@ farmdata2_modules/**/cypress/videos/*
 
 **/__pycache__
 
+**/node_modules
+
 .DS_Store

--- a/farmdata2_modules/fd2_tabs/resources/JSDoc.json
+++ b/farmdata2_modules/fd2_tabs/resources/JSDoc.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    "/usr/lib/node_modules/jsdoc-vuejs"
+    "node_modules/jsdoc-vuejs"
   ],
   "source": {
     "includePattern": "\\.(vue|js)$"

--- a/farmdata2_modules/fd2_tabs/resources/README.md
+++ b/farmdata2_modules/fd2_tabs/resources/README.md
@@ -12,8 +12,8 @@ The documentation for the Javascript library functions are generated using [JSDo
 
 To install the necessary tools:
 
-1. `sudo apt install npm`
-2. `sudo npm install -g jsdoc@3.6.7 jsdoc-vuejs@3.0.9 vue-template-compiler@2.6.14`
+1. `sudo apt install npm`  (if not already installed)
+2. `npm install -prefix . --no-package-lock jsdoc@3.6.7 jsdoc-vuejs@3.0.9 vue-template-compiler@2.6.14`
 
 ### Generating Documentation
 


### PR DESCRIPTION
__Pull Request Description__

Make the installation of JSDoc using npm local instead of global on the system.  This resolves an issue with use on machines that install the node_modules into different locations globally.

Closes #483 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
