### PR TITLE
Removed restart always for fd2_phpmyadmin container.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -41,7 +41,6 @@ services:
     container_name: fd2_phpmyadmin
     environment:
       PMA_HOST: "db"
-    restart: always
     ports:
       - 8181:80
     volumes:


### PR DESCRIPTION
__Pull Request Description__

The fd2_phpmyadmin container was restarting when the VM was shutdown and restarted.  This was inconsistent with the behavior of the other containers.  No no containers are restarted automatically.

Fixes #329 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
