### PR TITLE
DateRangeSelection: Removed leftover symbol inside template.

### DIFF
--- a/farmdata2_modules/fd2_tabs/resources/DateRangeSelectionComponent.js
+++ b/farmdata2_modules/fd2_tabs/resources/DateRangeSelectionComponent.js
@@ -29,7 +29,7 @@ catch(err) {
 let DateRangeSelectionComponent = {
     template: `<div>
                 <date-selection data-cy="start-date-select" :setDate="setStartDate" :latestDate="latestStartDate" @date-changed="startDateChange" 
-                @click="click" :disabled="isDisabled">>
+                @click="click" :disabled="isDisabled">
                     Start Date:
                 </date-selection>
                 <br>


### PR DESCRIPTION
__Pull Request Description__

Removed a leftover symbol from the *DateRangeSelection's* template that was being rendered into the page. 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
