### PR TITLE
Issue #357: Add buttons to test hide show column for CustomTableComponent

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_example/ui.html
+++ b/farmdata2_modules/fd2_tabs/fd2_example/ui.html
@@ -116,14 +116,12 @@
             @row-deleted="deleteTableRow"
             @row-edited="updateTableRow">
         </custom-table>
-        <!-- Does not work at present See Issue #357.
         <button data-cy='show-column' 
-            :disabled='tableVisibleColumns[2]'
+            v-show='!tableVisibleColumns[2]'
             @click='showColumn'>Show Column</button>
         <button data-cy='hide-column' 
-            :disabled='!tableVisibleColumns[2]'
+            v-show='tableVisibleColumns[2]'
             @click='hideColumn'>Hide Column</button>
-        -->
         <button data-cy='add-data' 
             @click='addDataRow'>Add Data Row</button>
     </UL>
@@ -306,13 +304,12 @@ new Vue({
 
             // Would also need to update data in the db via API here.
         },
-        //Does not work at present See Issue #357.
-        //showColumn() {
-        //    this.tableVisibleColumns[2] = true
-        //},
-        //hideColumn() {
-        //    this.tableVisibleColumns[2] = false
-        //},
+        showColumn() {
+            Vue.set(this.tableVisibleColumns, 2, true)      // reactive changes to arrays must be implemented this way (this.tableVisibleColumns[2] = true does not work)
+        },
+        hideColumn() {
+            Vue.set(this.tableVisibleColumns, 2, false)     // reactive changes to arrays must be implemented this way (this.tableVisibleColumns[2] = false does not work)
+        },
         addDataRow() {
             this.tableData.push({id: 4, data: ['12', 'Socks', 'L', 'Red', 22, '2020-04-01']})
         },

--- a/farmdata2_modules/fd2_tabs/fd2_example/ui.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_example/ui.spec.js
@@ -263,6 +263,19 @@ describe('Test the UI component', () => {
             cy.get('[data-cy=r3c0]')
                 .should('have.text', '12')
         })
+
+        it('size column shows when show column is clicked, hides when hide column is clicked', () => {
+            cy.get('[data-cy=table-headers]').children()
+                .should('not.contain', 'Size')
+            cy.get('[data-cy=show-column')
+                .click()
+            cy.get('[data-cy=table-headers]').children()
+                .should('contain', 'Size')
+            cy.get('[data-cy=hide-column')
+                .click()
+            cy.get('[data-cy=table-headers]').children()
+                .should('not.contain', 'Size')
+        })
     })
 
     context('check the spinner example', () => {

--- a/farmdata2_modules/fd2_tabs/resources/CustomTableComponent.js
+++ b/farmdata2_modules/fd2_tabs/resources/CustomTableComponent.js
@@ -233,9 +233,9 @@ let CustomTableComponent = {
                 for (i = 0; i < this.headers.length; i++) {
                     tempArr.push(true);
                 }
-            } else [
+            } else {
                 tempArr = this.updatedVis
-            ]
+            }
             return tempArr;
         },
         inputType() {

--- a/farmdata2_modules/fd2_tabs/resources/CustomTableComponent.spec.comp.js
+++ b/farmdata2_modules/fd2_tabs/resources/CustomTableComponent.spec.comp.js
@@ -495,7 +495,7 @@ describe('custom table component', () => {
             })    
         })
 
-        it.only('checking prop changes for visibleColumns when the element is directly modified', () => {
+        it('checking prop changes for visibleColumns when the element is directly modified', () => {
             expect(comp.vm.visibleColumns).to.deep.equal([true, true, false])
             cy.wrap(comp.vm.visibleColumns[0] = false)
             cy.wrap(comp.vm.visibleColumns[2] = true)


### PR DESCRIPTION
__Pull Request Description__

Fixes #357. Added two buttons to show and hide columns for the CustomTableComponent on the ui.html page. Added Cypress test to fix the issue. Also fixed minor syntax issues in CustomTableComponent and the test file. 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
