### PR TITLE
Implementing Standard Error Handling for API Request Failures

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -1,5 +1,8 @@
 <body>
     <div id="seedingReport" v-cloak>
+        <div data-cy='alert-err-handler'class="alert alert-danger" style="display: none;" role="alert" v-show="errBanner == true" @click="hideBanner">
+            Error Processing Request. This may be an intermittent network issue. Please try again later. 
+        </div>
         <h1 class="text-center">Seeding Report</h1>
         <fieldset :disabled="rowBeingEdited" class="panel panel-default center-block" style="width: 50%;">
             <legend class="panel-heading" style="background-color: #d62a17; color: white;">Set Dates</legend>
@@ -109,7 +112,8 @@
                 areaToIDMap: new Map(),
                 unitToIDMap: new Map(),
 
-                rowBeingEdited: false
+                rowBeingEdited: false,
+                errBanner: null,
             },
             methods: {
                 hide(){
@@ -130,9 +134,30 @@
                     this.reportVisible = true
                     let link = '/log.json?type=farm_seeding&timestamp[ge]=' + dayjs(this.startDate).unix() + '&timestamp[le]=' + dayjs(this.endDate).unix()
 
-                    getAllPages(link, this.seedingLogs).then(() => {
-                        this.stillLoading = false
-                    })
+                    getAllPages(link, this.seedingLogs)
+                        .then(() => {
+                            this.stillLoading = false
+                        })
+                        .catch((err) => { 
+                                if (err.response) {
+                                    // The request was made and the server responded with a status code
+                                    // that falls out of the range of 2xx
+                                    this.errBanner = true
+                                    console.log('Error code that falls out of 2xx.')
+                                } 
+                                else if (err.request) {
+                                    // The request was made but no response was received
+                                    // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                                    // http.ClientRequest in node.js
+                                    this.errBanner = true
+                                    console.log('No response was received');
+                                } 
+                                else {
+                                    // Something happened in setting up the request that triggered an Error
+                                    this.errBanner = true
+                                    console.log('Error Message: ', err.message);
+                                }
+                            })
                     this.stillLoading = true
                 },
                 cropChange(selectedCrop){
@@ -161,7 +186,6 @@
                     let updateSeedingObject = {}
                     let updatePlantObject = {}
                     
-                   
                     /**
                      * The Table component returns an object with the cells that were updated. We don't know how many or wich ones where updated, so we check for all possible cells that could have been updated.
                      */
@@ -287,6 +311,9 @@
                 enableFilters(){
                     this.rowBeingEdited = false
                 },
+                hideBanner(){
+                    this.errBanner = false
+                },
             },
             computed: {
                 /**
@@ -407,7 +434,7 @@
                     let areaArray = []
                     if(this.selectedCrop != 'All'){
                         let cropFilter = seedFilter.filter((x) => this.idToCropMap.get(x.data.crop_tid) === this.selectedCrop)
-                         areaArray = cropFilter.map(h =>
+                        areaArray = cropFilter.map(h =>
                             h.movement.area[0].name
                         )
                     }
@@ -504,7 +531,7 @@
                     let tableData = this.tableRows
                     let totalTraySeeds = 0
                     tableData.map(h =>
-                       totalTraySeeds = totalTraySeeds + parseFloat(h.data[7])
+                        totalTraySeeds = totalTraySeeds + parseFloat(h.data[7])
                     )
                     return totalTraySeeds
                 },
@@ -515,7 +542,7 @@
                     let tableData = this.tableRows
                     let totalTrays = 0
                     tableData.map(h =>
-                       totalTrays = totalTrays + parseFloat(h.data[8])
+                        totalTrays = totalTrays + parseFloat(h.data[8])
                     )
                     return (Math.round(totalTrays*100))/100
                 },
@@ -656,27 +683,174 @@
                 }
             },
             created() {
-                getSessionToken().then((response) => {
-                    this.sessionToken = response
-                })
-                getIDToCropMap().then((response) => {
-                    this.idToCropMap = new Map(response)
-                })
-                getCropToIDMap().then((response) => {
-                    this.cropToIDMap = new Map(response)
-                })
-                getIDToUserMap().then((response) => {
-                    this.idToUserMap = new Map (response)
-                })
-                getUserToIDMap().then((response) => {
-                    this.userToIDMap = new Map (response)
-                })
-                getAreaToIDMap().then((response) => {
-                    this.areaToIDMap = new Map(response)
-                })
-                getUnitToIDMap().then((response) => {
-                    this.unitToIDMap = new Map(response)
-                })
+                getSessionToken()
+                    .then((response) => {
+                        this.sessionToken = response
+                    })
+                    .catch((err) => { 
+                            if (err.response) {
+                                // The request was made and the server responded with a status code
+                                // that falls out of the range of 2xx
+                                this.errBanner = true
+                                console.log('Error code that falls out of 2xx.')
+                            } 
+                            else if (err.request) {
+                                // The request was made but no response was received
+                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                                // http.ClientRequest in node.js
+                                this.errBanner = true
+                                console.log('No response was received');
+                            } 
+                            else {
+                                // Something happened in setting up the request that triggered an Error
+                                this.errBanner = true
+                                console.log('Error Message: ', err.message);
+                            }
+                        })
+                getIDToCropMap()
+                    .then((response) => {
+                        this.idToCropMap = new Map(response)
+                    })
+                    .catch((err) => { 
+                                if (err.response) {
+                                    // The request was made and the server responded with a status code
+                                    // that falls out of the range of 2xx
+                                    this.errBanner = true
+                                    console.log('Error code that falls out of 2xx.')
+                                } 
+                                else if (err.request) {
+                                    // The request was made but no response was received
+                                    // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                                    // http.ClientRequest in node.js
+                                    this.errBanner = true
+                                    console.log('No response was received');
+                                } 
+                                else {
+                                    // Something happened in setting up the request that triggered an Error
+                                    this.errBanner = true
+                                    console.log('Error Message: ', err.message);
+                                }
+                            })
+                getCropToIDMap()
+                    .then((response) => {
+                        this.cropToIDMap = new Map(response)
+                    })
+                    .catch((err) => { 
+                                if (err.response) {
+                                    // The request was made and the server responded with a status code
+                                    // that falls out of the range of 2xx
+                                    this.errBanner = true
+                                    console.log('Error code that falls out of 2xx.')
+                                } 
+                                else if (err.request) {
+                                    // The request was made but no response was received
+                                    // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                                    // http.ClientRequest in node.js
+                                    this.errBanner = true
+                                    console.log('No response was received');
+                                } 
+                                else {
+                                    // Something happened in setting up the request that triggered an Error
+                                    this.errBanner = true
+                                    console.log('Error Message: ', err.message);
+                                }
+                            })
+                getIDToUserMap()
+                    .then((response) => {
+                        this.idToUserMap = new Map (response)
+                    })
+                    .catch((err) => { 
+                                if (err.response) {
+                                    // The request was made and the server responded with a status code
+                                    // that falls out of the range of 2xx
+                                    this.errBanner = true
+                                    console.log('Error code that falls out of 2xx.')
+                                } 
+                                else if (err.request) {
+                                    // The request was made but no response was received
+                                    // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                                    // http.ClientRequest in node.js
+                                    this.errBanner = true
+                                    console.log('No response was received');
+                                } 
+                                else {
+                                    // Something happened in setting up the request that triggered an Error
+                                    this.errBanner = true
+                                    console.log('Error Message: ', err.message);
+                                }
+                            })
+                getUserToIDMap()
+                    .then((response) => {
+                        this.userToIDMap = new Map (response)
+                    })
+                    .catch((err) => { 
+                                if (err.response) {
+                                    // The request was made and the server responded with a status code
+                                    // that falls out of the range of 2xx
+                                    this.errBanner = true
+                                    console.log('Error code that falls out of 2xx.')
+                                } 
+                                else if (err.request) {
+                                    // The request was made but no response was received
+                                    // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                                    // http.ClientRequest in node.js
+                                    this.errBanner = true
+                                    console.log('No response was received');
+                                } 
+                                else {
+                                    // Something happened in setting up the request that triggered an Error
+                                    this.errBanner = true
+                                    console.log('Error Message: ', err.message);
+                                }
+                            })
+                getAreaToIDMap()
+                    .then((response) => {
+                        this.areaToIDMap = new Map(response)
+                    })
+                    .catch((err) => { 
+                                if (err.response) {
+                                    // The request was made and the server responded with a status code
+                                    // that falls out of the range of 2xx
+                                    this.errBanner = true
+                                    console.log('Error code that falls out of 2xx.')
+                                } 
+                                else if (err.request) {
+                                    // The request was made but no response was received
+                                    // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                                    // http.ClientRequest in node.js
+                                    this.errBanner = true
+                                    console.log('No response was received');
+                                } 
+                                else {
+                                    // Something happened in setting up the request that triggered an Error
+                                    this.errBanner = true
+                                    console.log('Error Message: ', err.message);
+                                }
+                            })
+                getUnitToIDMap()
+                    .then((response) => {
+                        this.unitToIDMap = new Map(response)
+                    })
+                    .catch((err) => { 
+                                if (err.response) {
+                                    // The request was made and the server responded with a status code
+                                    // that falls out of the range of 2xx
+                                    this.errBanner = true
+                                    console.log('Error code that falls out of 2xx.')
+                                } 
+                                else if (err.request) {
+                                    // The request was made but no response was received
+                                    // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                                    // http.ClientRequest in node.js
+                                    this.errBanner = true
+                                    console.log('No response was received');
+                                } 
+                                else {
+                                    // Something happened in setting up the request that triggered an Error
+                                    this.errBanner = true
+                                    console.log('Error Message: ', err.message);
+                                }
+                            })
             }
         });
         Vue.config.devtools = true;

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -140,22 +140,13 @@
                         })
                         .catch((err) => { 
                                 if (err.response) {
-                                    // The request was made and the server responded with a status code
-                                    // that falls out of the range of 2xx
                                     this.errBanner = true
-                                    console.log('Error code that falls out of 2xx.')
                                 } 
                                 else if (err.request) {
-                                    // The request was made but no response was received
-                                    // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-                                    // http.ClientRequest in node.js
                                     this.errBanner = true
-                                    console.log('No response was received');
                                 } 
                                 else {
-                                    // Something happened in setting up the request that triggered an Error
                                     this.errBanner = true
-                                    console.log('Error Message: ', err.message);
                                 }
                             })
                     this.stillLoading = true
@@ -689,22 +680,13 @@
                     })
                     .catch((err) => { 
                             if (err.response) {
-                                // The request was made and the server responded with a status code
-                                // that falls out of the range of 2xx
                                 this.errBanner = true
-                                console.log('Error code that falls out of 2xx.')
                             } 
                             else if (err.request) {
-                                // The request was made but no response was received
-                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-                                // http.ClientRequest in node.js
                                 this.errBanner = true
-                                console.log('No response was received');
                             } 
                             else {
-                                // Something happened in setting up the request that triggered an Error
                                 this.errBanner = true
-                                console.log('Error Message: ', err.message);
                             }
                         })
                 getIDToCropMap()
@@ -712,145 +694,92 @@
                         this.idToCropMap = new Map(response)
                     })
                     .catch((err) => { 
-                                if (err.response) {
-                                    // The request was made and the server responded with a status code
-                                    // that falls out of the range of 2xx
-                                    this.errBanner = true
-                                    console.log('Error code that falls out of 2xx.')
-                                } 
-                                else if (err.request) {
-                                    // The request was made but no response was received
-                                    // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-                                    // http.ClientRequest in node.js
-                                    this.errBanner = true
-                                    console.log('No response was received');
-                                } 
-                                else {
-                                    // Something happened in setting up the request that triggered an Error
-                                    this.errBanner = true
-                                    console.log('Error Message: ', err.message);
-                                }
-                            })
+                        if (err.response) {
+                            this.errBanner = true
+                        } 
+                        else if (err.request) {
+                            this.errBanner = true
+                        } 
+                        else {
+                            this.errBanner = true
+                        }
+                    })
                 getCropToIDMap()
                     .then((response) => {
                         this.cropToIDMap = new Map(response)
                     })
                     .catch((err) => { 
-                                if (err.response) {
-                                    // The request was made and the server responded with a status code
-                                    // that falls out of the range of 2xx
-                                    this.errBanner = true
-                                    console.log('Error code that falls out of 2xx.')
-                                } 
-                                else if (err.request) {
-                                    // The request was made but no response was received
-                                    // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-                                    // http.ClientRequest in node.js
-                                    this.errBanner = true
-                                    console.log('No response was received');
-                                } 
-                                else {
-                                    // Something happened in setting up the request that triggered an Error
-                                    this.errBanner = true
-                                    console.log('Error Message: ', err.message);
-                                }
-                            })
+                        if (err.response) {
+                            this.errBanner = true
+                        } 
+                        else if (err.request) {
+                            this.errBanner = true
+                        } 
+                        else {
+                            this.errBanner = true
+                        }
+                    })
                 getIDToUserMap()
                     .then((response) => {
                         this.idToUserMap = new Map (response)
                     })
                     .catch((err) => { 
-                                if (err.response) {
-                                    // The request was made and the server responded with a status code
-                                    // that falls out of the range of 2xx
-                                    this.errBanner = true
-                                    console.log('Error code that falls out of 2xx.')
-                                } 
-                                else if (err.request) {
-                                    // The request was made but no response was received
-                                    // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-                                    // http.ClientRequest in node.js
-                                    this.errBanner = true
-                                    console.log('No response was received');
-                                } 
-                                else {
-                                    // Something happened in setting up the request that triggered an Error
-                                    this.errBanner = true
-                                    console.log('Error Message: ', err.message);
-                                }
-                            })
+                        if (err.response) {
+                            this.errBanner = true
+                        } 
+                        else if (err.request) {
+                            this.errBanner = true
+                        } 
+                        else {
+                            this.errBanner = true
+                        }
+                    })
                 getUserToIDMap()
                     .then((response) => {
                         this.userToIDMap = new Map (response)
                     })
                     .catch((err) => { 
-                                if (err.response) {
-                                    // The request was made and the server responded with a status code
-                                    // that falls out of the range of 2xx
-                                    this.errBanner = true
-                                    console.log('Error code that falls out of 2xx.')
-                                } 
-                                else if (err.request) {
-                                    // The request was made but no response was received
-                                    // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-                                    // http.ClientRequest in node.js
-                                    this.errBanner = true
-                                    console.log('No response was received');
-                                } 
-                                else {
-                                    // Something happened in setting up the request that triggered an Error
-                                    this.errBanner = true
-                                    console.log('Error Message: ', err.message);
-                                }
-                            })
+                        if (err.response) {
+                            this.errBanner = true
+                        } 
+                        else if (err.request) {
+                            this.errBanner = true
+                        } 
+                        else {
+                            this.errBanner = true
+                        }
+                    })
                 getAreaToIDMap()
                     .then((response) => {
                         this.areaToIDMap = new Map(response)
                     })
                     .catch((err) => { 
-                                if (err.response) {
-                                    // The request was made and the server responded with a status code
-                                    // that falls out of the range of 2xx
-                                    this.errBanner = true
-                                    console.log('Error code that falls out of 2xx.')
-                                } 
-                                else if (err.request) {
-                                    // The request was made but no response was received
-                                    // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-                                    // http.ClientRequest in node.js
-                                    this.errBanner = true
-                                    console.log('No response was received');
-                                } 
-                                else {
-                                    // Something happened in setting up the request that triggered an Error
-                                    this.errBanner = true
-                                    console.log('Error Message: ', err.message);
-                                }
-                            })
+                        if (err.response) {
+                            this.errBanner = true
+                        } 
+                        else if (err.request) {
+                            this.errBanner = true
+                            console.log('No response was received');
+                        } 
+                        else {
+                            this.errBanner = true
+                        }
+                    })
                 getUnitToIDMap()
                     .then((response) => {
                         this.unitToIDMap = new Map(response)
                     })
                     .catch((err) => { 
-                                if (err.response) {
-                                    // The request was made and the server responded with a status code
-                                    // that falls out of the range of 2xx
-                                    this.errBanner = true
-                                    console.log('Error code that falls out of 2xx.')
-                                } 
-                                else if (err.request) {
-                                    // The request was made but no response was received
-                                    // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-                                    // http.ClientRequest in node.js
-                                    this.errBanner = true
-                                    console.log('No response was received');
-                                } 
-                                else {
-                                    // Something happened in setting up the request that triggered an Error
-                                    this.errBanner = true
-                                    console.log('Error Message: ', err.message);
-                                }
-                            })
+                        if (err.response) {
+                            this.errBanner = true
+                        } 
+                        else if (err.request) {
+                            this.errBanner = true
+                        } 
+                        else {
+                            this.errBanner = true
+                        }
+                    })
             }
         });
         Vue.config.devtools = true;

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -140,7 +140,7 @@
                         })
                         .catch((err) => { 
                             this.errBanner = true
-                            scrollTo({
+                            scrollBy({
                                 top: 0,
                                 behavior: 'smooth'
                             })
@@ -676,7 +676,7 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
-                        scrollTo({
+                        scrollBy({
                             top: 0,
                             behavior: 'smooth'
                         })
@@ -687,7 +687,7 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
-                        scrollTo({
+                        scrollBy({
                             top: 0,
                             behavior: 'smooth'
                         })
@@ -698,7 +698,7 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
-                        scrollTo({
+                        scrollBy({
                             top: 0,
                             behavior: 'smooth'
                         })
@@ -709,7 +709,7 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
-                        scrollTo({
+                        scrollBy({
                             top: 0,
                             behavior: 'smooth'
                         })
@@ -720,7 +720,7 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
-                        scrollTo({
+                        scrollBy({
                             top: 0,
                             behavior: 'smooth'
                         })
@@ -731,7 +731,7 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
-                        scrollTo({
+                        scrollBy({
                             top: 0,
                             behavior: 'smooth'
                         })
@@ -742,7 +742,7 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
-                        scrollTo({
+                        scrollBy({
                             top: 0,
                             behavior: 'smooth'
                         })

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -1,9 +1,11 @@
 <body>
     <div id="seedingReport" v-cloak>
-        <div data-cy='alert-err-handler'class="alert alert-danger" style="display: none;" role="alert" v-show="errBanner == true" @click="hideBanner">
-            Error Processing Request. This may be an intermittent network issue. Please try again later. 
-        </div>
         <h1 class="text-center">Seeding Report</h1>
+        <div data-cy="alert-container" id="scrollBanners" class="alert-boxs" style='max-width: 500px; text-align: center; margin:auto; font-size: large'>
+            <div data-cy='alert-err-handler' class="alert alert-danger" style="display: none;" role="alert" v-show="errBanner == true" @click="hideBanner">
+                Error Processing Request. This may be an intermittent network issue. Please try again later. 
+            </div>
+        </div>
         <fieldset :disabled="rowBeingEdited" class="panel panel-default center-block" style="width: 50%;">
             <legend class="panel-heading" style="background-color: #d62a17; color: white;">Set Dates</legend>
             <div style="display: flex;width: 100%; padding: 7px">
@@ -140,8 +142,12 @@
                         })
                         .catch((err) => { 
                             this.errBanner = true
+                            var errorBanner = document.getElementById('scrollBanners')
+                            var pageHeader = document.getElementById('navbar')
+                            var headerBounds = pageHeader.getBoundingClientRect()
+                            var alertBounds = errorBanner.getBoundingClientRect()
                             scrollBy({
-                                top: 0,
+                                top: alertBounds.top - headerBounds.bottom,
                                 behavior: 'smooth'
                             })
                         })
@@ -676,8 +682,12 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
                         scrollBy({
-                            top: 0,
+                            top: alertBounds.top - headerBounds.bottom,
                             behavior: 'smooth'
                         })
                     })
@@ -687,8 +697,12 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
                         scrollBy({
-                            top: 0,
+                            top: alertBounds.top - headerBounds.bottom,
                             behavior: 'smooth'
                         })
                     })
@@ -698,8 +712,12 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
                         scrollBy({
-                            top: 0,
+                            top: alertBounds.top - headerBounds.bottom,
                             behavior: 'smooth'
                         })
                     })
@@ -709,8 +727,12 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
                         scrollBy({
-                            top: 0,
+                            top: alertBounds.top - headerBounds.bottom,
                             behavior: 'smooth'
                         })
                     })
@@ -720,8 +742,12 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
                         scrollBy({
-                            top: 0,
+                            top: alertBounds.top - headerBounds.bottom,
                             behavior: 'smooth'
                         })
                     })
@@ -731,8 +757,12 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
                         scrollBy({
-                            top: 0,
+                            top: alertBounds.top - headerBounds.bottom,
                             behavior: 'smooth'
                         })
                     })
@@ -742,8 +772,12 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
                         scrollBy({
-                            top: 0,
+                            top: alertBounds.top - headerBounds.bottom,
                             behavior: 'smooth'
                         })
                     })

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -148,6 +148,10 @@
                                 else {
                                     this.errBanner = true
                                 }
+                                scrollTo({
+                                    top: 0,
+                                    behavior: 'smooth'
+                                })
                             })
                     this.stillLoading = true
                 },
@@ -688,6 +692,10 @@
                             else {
                                 this.errBanner = true
                             }
+                            scrollTo({
+                                top: 0,
+                                behavior: 'smooth'
+                            })
                         })
                 getIDToCropMap()
                     .then((response) => {
@@ -703,6 +711,10 @@
                         else {
                             this.errBanner = true
                         }
+                        scrollTo({
+                            top: 0,
+                            behavior: 'smooth'
+                        })
                     })
                 getCropToIDMap()
                     .then((response) => {
@@ -718,6 +730,10 @@
                         else {
                             this.errBanner = true
                         }
+                        scrollTo({
+                            top: 0,
+                            behavior: 'smooth'
+                        })
                     })
                 getIDToUserMap()
                     .then((response) => {
@@ -733,6 +749,10 @@
                         else {
                             this.errBanner = true
                         }
+                        scrollTo({
+                            top: 0,
+                            behavior: 'smooth'
+                        })
                     })
                 getUserToIDMap()
                     .then((response) => {
@@ -748,6 +768,10 @@
                         else {
                             this.errBanner = true
                         }
+                        scrollTo({
+                            top: 0,
+                            behavior: 'smooth'
+                        })
                     })
                 getAreaToIDMap()
                     .then((response) => {
@@ -764,6 +788,10 @@
                         else {
                             this.errBanner = true
                         }
+                        scrollTo({
+                            top: 0,
+                            behavior: 'smooth'
+                        })
                     })
                 getUnitToIDMap()
                     .then((response) => {
@@ -779,6 +807,10 @@
                         else {
                             this.errBanner = true
                         }
+                        scrollTo({
+                            top: 0,
+                            behavior: 'smooth'
+                        })
                     })
             }
         });

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -139,20 +139,12 @@
                             this.stillLoading = false
                         })
                         .catch((err) => { 
-                                if (err.response) {
-                                    this.errBanner = true
-                                } 
-                                else if (err.request) {
-                                    this.errBanner = true
-                                } 
-                                else {
-                                    this.errBanner = true
-                                }
-                                scrollTo({
-                                    top: 0,
-                                    behavior: 'smooth'
-                                })
+                            this.errBanner = true
+                            scrollTo({
+                                top: 0,
+                                behavior: 'smooth'
                             })
+                        })
                     this.stillLoading = true
                 },
                 cropChange(selectedCrop){
@@ -683,34 +675,18 @@
                         this.sessionToken = response
                     })
                     .catch((err) => { 
-                            if (err.response) {
-                                this.errBanner = true
-                            } 
-                            else if (err.request) {
-                                this.errBanner = true
-                            } 
-                            else {
-                                this.errBanner = true
-                            }
-                            scrollTo({
-                                top: 0,
-                                behavior: 'smooth'
-                            })
+                        this.errBanner = true
+                        scrollTo({
+                            top: 0,
+                            behavior: 'smooth'
                         })
+                    })
                 getIDToCropMap()
                     .then((response) => {
                         this.idToCropMap = new Map(response)
                     })
                     .catch((err) => { 
-                        if (err.response) {
-                            this.errBanner = true
-                        } 
-                        else if (err.request) {
-                            this.errBanner = true
-                        } 
-                        else {
-                            this.errBanner = true
-                        }
+                        this.errBanner = true
                         scrollTo({
                             top: 0,
                             behavior: 'smooth'
@@ -721,15 +697,7 @@
                         this.cropToIDMap = new Map(response)
                     })
                     .catch((err) => { 
-                        if (err.response) {
-                            this.errBanner = true
-                        } 
-                        else if (err.request) {
-                            this.errBanner = true
-                        } 
-                        else {
-                            this.errBanner = true
-                        }
+                        this.errBanner = true
                         scrollTo({
                             top: 0,
                             behavior: 'smooth'
@@ -740,15 +708,7 @@
                         this.idToUserMap = new Map (response)
                     })
                     .catch((err) => { 
-                        if (err.response) {
-                            this.errBanner = true
-                        } 
-                        else if (err.request) {
-                            this.errBanner = true
-                        } 
-                        else {
-                            this.errBanner = true
-                        }
+                        this.errBanner = true
                         scrollTo({
                             top: 0,
                             behavior: 'smooth'
@@ -759,15 +719,7 @@
                         this.userToIDMap = new Map (response)
                     })
                     .catch((err) => { 
-                        if (err.response) {
-                            this.errBanner = true
-                        } 
-                        else if (err.request) {
-                            this.errBanner = true
-                        } 
-                        else {
-                            this.errBanner = true
-                        }
+                        this.errBanner = true
                         scrollTo({
                             top: 0,
                             behavior: 'smooth'
@@ -778,16 +730,7 @@
                         this.areaToIDMap = new Map(response)
                     })
                     .catch((err) => { 
-                        if (err.response) {
-                            this.errBanner = true
-                        } 
-                        else if (err.request) {
-                            this.errBanner = true
-                            console.log('No response was received');
-                        } 
-                        else {
-                            this.errBanner = true
-                        }
+                        this.errBanner = true
                         scrollTo({
                             top: 0,
                             behavior: 'smooth'
@@ -798,22 +741,14 @@
                         this.unitToIDMap = new Map(response)
                     })
                     .catch((err) => { 
-                        if (err.response) {
-                            this.errBanner = true
-                        } 
-                        else if (err.request) {
-                            this.errBanner = true
-                        } 
-                        else {
-                            this.errBanner = true
-                        }
+                        this.errBanner = true
                         scrollTo({
                             top: 0,
                             behavior: 'smooth'
                         })
                     })
             }
-        });
+        })
         Vue.config.devtools = true;
     </script>
 </body>

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
@@ -117,6 +117,8 @@ describe('Testing for the seeding report page', () => {
             cy.wait('@getAPIFailure')
             .then(() => {
                 cy.get('[data-cy=alert-err-handler]')
+                cy.window().its('scrollY').should('equal', 0)
+                cy.get('[data-cy=alert-err-handler]')
                 .should('be.visible')
                 .click()
                 .should('not.visible')
@@ -150,6 +152,8 @@ describe('Testing for the seeding report page', () => {
                 .click()
             cy.wait('@getAPIFailure')
             .then(() => {
+                cy.get('[data-cy=alert-err-handler]')
+                cy.window().its('scrollY').should('equal', 0)
                 cy.get('[data-cy=alert-err-handler]')
                 .should('be.visible')
                 .click()
@@ -1141,6 +1145,8 @@ describe('Testing for the seeding report page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 
@@ -1152,6 +1158,8 @@ describe('Testing for the seeding report page', () => {
             cy.visit('/farm/fd2-barn-kit/seedingReport')
             cy.wait('@failedSessionTok')
                 .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    cy.window().its('scrollY').should('equal', 0)
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
                     .click()
@@ -1172,6 +1180,8 @@ describe('Testing for the seeding report page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 
@@ -1185,6 +1195,8 @@ describe('Testing for the seeding report page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 
@@ -1203,6 +1215,8 @@ describe('Testing for the seeding report page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 
@@ -1216,6 +1230,8 @@ describe('Testing for the seeding report page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 
@@ -1234,6 +1250,8 @@ describe('Testing for the seeding report page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 
@@ -1247,6 +1265,8 @@ describe('Testing for the seeding report page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 
@@ -1265,6 +1285,8 @@ describe('Testing for the seeding report page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 
@@ -1278,6 +1300,8 @@ describe('Testing for the seeding report page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
@@ -98,7 +98,75 @@ describe('Testing for the seeding report page', () => {
 
             cy.get('[data-cy=tray-summary]')
                 .should('exist')
-        })       
+        })
+
+        it('generate report experiences API error: outside of 2xx error code', () => {
+            cy.get('[data-cy=date-range-selection]')
+                .should('exist')
+            cy.get('[data-cy=start-date-select]')
+                .should('exist')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .should('exist')
+                .type('2019-03-01')
+
+            cy.intercept('GET', '/log.json?type=farm_seeding&timestamp[ge]=1546300800&timestamp[le]=1551398400', { statusCode: 500 })
+            .as('getAPIFailure')
+            cy.get('[data-cy=generate-rpt-btn]')
+                .click()
+            cy.wait('@getAPIFailure')
+            .then(() => {
+                cy.get('[data-cy=alert-err-handler]')
+                .should('be.visible')
+                .click()
+                .should('not.visible')
+            }) 
+            cy.get('[data-cy=filters-panel]')
+                .should('not.exist')
+
+            cy.get('[data-cy=report-table]')
+                .should('not.exist')
+
+            cy.get('[data-cy=direct-summary]')
+                .should('not.exist')
+
+            cy.get('[data-cy=tray-summary]')
+                .should('not.exist')
+        }) 
+
+        it('generate report experiences API error: network error', () => {
+            cy.get('[data-cy=date-range-selection]')
+                .should('exist')
+            cy.get('[data-cy=start-date-select]')
+                .should('exist')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .should('exist')
+                .type('2019-03-01')
+
+            cy.intercept('GET', '/log.json?type=farm_seeding&timestamp[ge]=1546300800&timestamp[le]=1551398400', { forceNetworkError: true })
+            .as('getAPIFailure')
+            cy.get('[data-cy=generate-rpt-btn]')
+                .click()
+            cy.wait('@getAPIFailure')
+            .then(() => {
+                cy.get('[data-cy=alert-err-handler]')
+                .should('be.visible')
+                .click()
+                .should('not.visible')
+            }) 
+            cy.get('[data-cy=filters-panel]')
+                .should('not.exist')
+
+            cy.get('[data-cy=report-table]')
+                .should('not.exist')
+
+            cy.get('[data-cy=direct-summary]')
+                .should('not.exist')
+
+            cy.get('[data-cy=tray-summary]')
+                .should('not.exist')
+        }) 
     })
 
     context('assures filters are actually populated', () => {
@@ -272,15 +340,6 @@ describe('Testing for the seeding report page', () => {
                 .type('2021-01-01')
             cy.get('[data-cy=end-date-select]')
                 .type('2021-03-01')
-            cy.get('[data-cy=generate-rpt-btn]').click()
-            cy.get('[data-cy=no-logs-message]').should('be.visible')
-        })
-
-        it('the No Logs message appears with a reinputted table with logs', () => {
-            cy.get('[data-cy=start-date-select]')
-                .type('2030-01-01')
-            cy.get('[data-cy=end-date-select]')
-                .type('2030-03-01')
             cy.get('[data-cy=generate-rpt-btn]').click()
             cy.get('[data-cy=no-logs-message]').should('be.visible')
         })
@@ -1058,10 +1117,6 @@ describe('Testing for the seeding report page', () => {
             cy.get('@seedingDelete').should((response) => {
                 expect(response.status).to.equal(200)
             })
-
-
-            
-
         })
 
         it('deletes a log from the database when the delete button is pressed', () => {
@@ -1070,5 +1125,167 @@ describe('Testing for the seeding report page', () => {
                     expect(response.status).to.equal(200)
                 })
         })
+    })
+
+    context('make sure any APIs that fail on page load make the API failed alert appear', () => {
+        beforeEach(() => {
+            cy.login('manager1', 'farmdata2')
+            
+        })
+        
+        it('fail the session token API: outside of 2xx error code', () => {
+            cy.intercept('GET', 'restws/session/token', { statusCode: 500 }).as('failedSessionTok')
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.wait('@failedSessionTok')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        it('fail the session token API: network error', () => {
+            cy.intercept('GET', 'restws/session/token', { forceNetworkError: true }).as('failedSessionTok')
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.wait('@failedSessionTok')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        // if something else happens while setting up the request
+        // then it would also be handled here. 
+        // it('fail the session token API: something happened that triggered an error', () => {
+        // })
+
+        it('fail the crop map API: outside of 2xx error code', () => {
+            cy.intercept('GET', 'taxonomy_term?bundle=farm_crops&page=1', { statusCode: 500 }).as('failedCropMap')
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.wait('@failedCropMap')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        it('fail the crop map API: network error', () => {
+            cy.intercept('GET', 'taxonomy_term?bundle=farm_crops&page=1', { forceNetworkError: true }).as('failedCropMap')
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.wait('@failedCropMap')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        // if something else happens while setting up the request
+        // then it would also be handled here. 
+        // it('fail the crop map API: something happened that triggered an error', () => {
+        // })
+
+        it('fail the user map API: outside of 2xx error code', () => {
+            cy.intercept('GET', 'user', { statusCode: 500 }).as('failedUserMap')
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')         
+            cy.wait('@failedUserMap')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        it('fail the user map API: network error', () => {
+            cy.intercept('GET', 'user', { forceNetworkError: true }).as('failedUserMap')
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')         
+            cy.wait('@failedUserMap')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        // if something else happens while setting up the request
+        // then it would also be handled here. 
+        // it('fail the user map API: something happened that triggered an error', () => {
+        // })
+        
+        it('fail the area map API: outside of 2xx error code', () => {
+            cy.intercept('GET', 'taxonomy_term.json?bundle=farm_areas', { statusCode: 500 }).as('failedAreaMap') 
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.wait('@failedAreaMap')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        it('fail the area map API: outside of network error', () => {
+            cy.intercept('GET', 'taxonomy_term.json?bundle=farm_areas', { forceNetworkError: true }).as('failedAreaMap') 
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.wait('@failedAreaMap')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        // if something else happens while setting up the request
+        // then it would also be handled here. 
+        // it('fail the area map API: something happened that triggered an error', () => {
+        // })
+
+        it('fail the unit map API: outside of 2xx error code', () => {
+            cy.intercept('GET', 'taxonomy_term.json?bundle=farm_quantity_units', { statusCode: 500 }).as('failedUnitMap')
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.wait('@failedUnitMap')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        it('fail the unit map API: network error', () => {
+            cy.intercept('GET', 'taxonomy_term.json?bundle=farm_quantity_units', { forceNetworkError: true }).as('failedUnitMap')
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.wait('@failedUnitMap')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        // if something else happens while setting up the request
+        // then it would also be handled here. 
+        // it('fail the unit map API: something happened that triggered an error', () => {
+        // })
     })
 })

--- a/farmdata2_modules/fd2_tabs/fd2_example/ui.html
+++ b/farmdata2_modules/fd2_tabs/fd2_example/ui.html
@@ -340,7 +340,7 @@ new Vue({
             // To display the spinner
             this.waitingOnLogs = true
 
-            //this.seedingLogs = []
+            this.seedingLogs = []
 
             // Then invoke one of the FarmOSAPI methods and setup
             // what to do when the API call completes.
@@ -354,6 +354,8 @@ new Vue({
         badAPICall() {
             // To display the spinner
             this.waitingOnErr = true
+
+            this.seedingLogs = []
 
             // Purposely has a bad API call so behavior is the same
             // every single time

--- a/farmdata2_modules/fd2_tabs/fd2_example/ui.html
+++ b/farmdata2_modules/fd2_tabs/fd2_example/ui.html
@@ -170,6 +170,27 @@
         class="loader center-block" 
         v-if="waitingOnLogs"></div>
     </UL>
+
+    <p><b>API Error Handling</b></p>
+    <div data-cy='alert-err-handler'class="alert alert-danger" style="display: none;" role="alert" v-show="errBanner == true" @click="hideBanner">
+        Error Processing Request. This may be an intermittent network issue. Please try again later. 
+    </div>
+    <UL>
+        <button data-cy='fetch-err-api'
+            :disabled='waitingOnLogs' 
+            @click='badAPICall'>Fetch All Seeding Logs</button>
+        <p>Result:</p>
+        <UL>
+            <p>Purposely makes an erroneous API call to demonstrate how the API error handler deals with errors in API requests</p>
+
+            <LI>First Log Name: <span data-cy='first-err-log'>{{ firstSeedingLogName }}</span>
+            <LI>Last Log Name: <span data-cy='second-err-log'>{{ lastSeedingLogName }}</span>
+        </UL>
+        
+        <div data-cy="loading-err-spinner" 
+        class="loader center-block" 
+        v-if="waitingOnErr"></div>
+    </UL>
 </div>
 
 <script>
@@ -219,6 +240,8 @@ new Vue({
         tableVisibleColumns: [true, true, false, true, true, true],
 
         waitingOnLogs: false,
+        waitingOnErr: false,
+        errBanner: false,
         seedingLogs: [],
 
         regularExp: null,
@@ -314,10 +337,10 @@ new Vue({
             this.tableData.push({id: 4, data: ['12', 'Socks', 'L', 'Red', 22, '2020-04-01']})
         },
         fetchSeedingLogs() {
-            // To use the spinner display it
+            // To display the spinner
             this.waitingOnLogs = true
 
-            this.seedingLogs = []
+            //this.seedingLogs = []
 
             // Then invoke one of the FarmOSAPI methods and setup
             // what to do when the API call completes.
@@ -327,6 +350,23 @@ new Vue({
             .then(() => {
                 this.waitingOnLogs = false
             })
+        },
+        badAPICall() {
+            // To display the spinner
+            this.waitingOnErr = true
+
+            getAllPages('abc')
+            .then(() => {
+                this.waitingOnErr = false
+            })
+            .catch((err) => { 
+                this.waitingOnErr = false
+                this.errBanner = true
+
+            })
+        },
+        hideBanner(){
+            this.errBanner = false
         },
     },
     computed: {

--- a/farmdata2_modules/fd2_tabs/fd2_example/ui.html
+++ b/farmdata2_modules/fd2_tabs/fd2_example/ui.html
@@ -355,14 +355,34 @@ new Vue({
             // To display the spinner
             this.waitingOnErr = true
 
+            // Purposely has a bad API call so behavior is the same
+            // every single time
             getAllPages('abc')
             .then(() => {
                 this.waitingOnErr = false
             })
             .catch((err) => { 
-                this.waitingOnErr = false
-                this.errBanner = true
-
+                if (err.response) {
+                    // The request was made and the server responded with a status code
+                    // that falls out of the range of 2xx
+                    this.errBanner = true
+                    this.waitingOnErr = false
+                    console.log('Error code that falls out of 2xx.')
+                } 
+                else if (err.request) {
+                    // The request was made but no response was received
+                    // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                    // http.ClientRequest in node.js
+                    this.errBanner = true
+                    this.waitingOnErr = false
+                    console.log('No response was received');
+                } 
+                else {
+                    // Something happened in setting up the request that triggered an Error
+                    this.errBanner = true
+                    this.waitingOnErr = false
+                    console.log('Error Message: ', err.message);
+                }
             })
         },
         hideBanner(){

--- a/farmdata2_modules/fd2_tabs/fd2_example/ui.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_example/ui.spec.js
@@ -304,4 +304,38 @@ describe('Test the UI component', () => {
                 .should('not.exist')
         })
     })
+
+    context.only('check the api error handler example', () => {
+
+        it('spinner appears while loading', () => {
+            cy.get('[data-cy=alert-err-handler]')
+                .should('not.visible')
+            cy.get('[data-cy=loading-err-spinner]')
+                .should('not.exist')
+
+            cy.get('[data-cy=fetch-err-api]')
+                .click()
+
+            cy.get('[data-cy=alert-err-handler]')
+                .should('be.visible')
+            cy.get('[data-cy=first-log-name]')
+                .should('have.text','')
+            cy.get('[data-cy=loading-err-spinner]')
+                .should('not.exist')
+            cy.get('[data-cy=last-log-name]')
+                .should('have.text','')
+            cy.get('[data-cy=loading-err-spinner]')
+                .should('not.exist')
+            cy.get('[data-cy=last-log-name]')
+                .should('have.text','')
+        
+            cy.get('[data-cy=loading-err-spinner]')
+                .should('not.exist')
+
+            cy.get('[data-cy=alert-err-handler]')
+                .should('be.visible')
+                .click()
+                .should('not.visible')
+        })
+    })
 })

--- a/farmdata2_modules/fd2_tabs/fd2_example/ui.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_example/ui.spec.js
@@ -305,16 +305,20 @@ describe('Test the UI component', () => {
         })
     })
 
-    context.only('check the api error handler example', () => {
+    context('check the api error handler example', () => {
 
-        it('spinner appears while loading', () => {
+        it('forefully trigger an error code not within 2xx', () => {
             cy.get('[data-cy=alert-err-handler]')
                 .should('not.visible')
             cy.get('[data-cy=loading-err-spinner]')
                 .should('not.exist')
-
+                
+            cy.intercept('GET', '/farm/fd2-example/abc',{ statusCode: 500 })
+                .as('getServerFailure')
+            
             cy.get('[data-cy=fetch-err-api]')
                 .click()
+            cy.wait('@getServerFailure')
 
             cy.get('[data-cy=alert-err-handler]')
                 .should('be.visible')
@@ -332,6 +336,72 @@ describe('Test the UI component', () => {
             cy.get('[data-cy=loading-err-spinner]')
                 .should('not.exist')
 
+            cy.get('[data-cy=alert-err-handler]')
+                .should('be.visible')
+                .click()
+                .should('not.visible')
+        })
+
+        it('forefully trigger a network failure error', () => {
+            cy.get('[data-cy=alert-err-handler]')
+                .should('not.visible')
+            cy.get('[data-cy=loading-err-spinner]')
+                .should('not.exist')
+            
+            cy.intercept('GET', '/farm/fd2-example/abc',{ forceNetworkError: true })
+                .as('getNetworkFailure')
+            
+            cy.get('[data-cy=fetch-err-api]')
+                .click()
+            cy.wait('@getNetworkFailure')
+        
+            cy.get('[data-cy=alert-err-handler]')
+                .should('be.visible')
+            cy.get('[data-cy=first-log-name]')
+                .should('have.text','')
+            cy.get('[data-cy=loading-err-spinner]')
+                .should('not.exist')
+            cy.get('[data-cy=last-log-name]')
+                .should('have.text','')
+            cy.get('[data-cy=loading-err-spinner]')
+                .should('not.exist')
+            cy.get('[data-cy=last-log-name]')
+                .should('have.text','')
+        
+            cy.get('[data-cy=loading-err-spinner]')
+                .should('not.exist')
+    
+            cy.get('[data-cy=alert-err-handler]')
+                .should('be.visible')
+                .click()
+                .should('not.visible')
+        })
+
+        it('something happened while setting up the request that triggered an error', () => {
+            cy.get('[data-cy=alert-err-handler]')
+                .should('not.visible')
+            cy.get('[data-cy=loading-err-spinner]')
+                .should('not.exist')
+            
+            cy.get('[data-cy=fetch-err-api]')
+                .click()
+        
+            cy.get('[data-cy=alert-err-handler]')
+                .should('be.visible')
+            cy.get('[data-cy=first-log-name]')
+                .should('have.text','')
+            cy.get('[data-cy=loading-err-spinner]')
+                .should('not.exist')
+            cy.get('[data-cy=last-log-name]')
+                .should('have.text','')
+            cy.get('[data-cy=loading-err-spinner]')
+                .should('not.exist')
+            cy.get('[data-cy=last-log-name]')
+                .should('have.text','')
+        
+            cy.get('[data-cy=loading-err-spinner]')
+                .should('not.exist')
+    
             cy.get('[data-cy=alert-err-handler]')
                 .should('be.visible')
                 .click()

--- a/farmdata2_modules/fd2_tabs/fd2_example/ui.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_example/ui.spec.js
@@ -348,7 +348,7 @@ describe('Test the UI component', () => {
             cy.get('[data-cy=loading-err-spinner]')
                 .should('not.exist')
             
-            cy.intercept('GET', '/farm/fd2-example/abc',{ forceNetworkError: true })
+            cy.intercept('GET', '/farm/fd2-example/abc', { forceNetworkError: true })
                 .as('getNetworkFailure')
             
             cy.get('[data-cy=fetch-err-api]')

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
@@ -2,6 +2,9 @@
     <div id='seedingInput'>
         <h1 style='text-align:center;'>Seeding Input Log</h1> 
         <div data-cy="alert-container" id="scrollBanners" class="alert-boxs" style='max-width: 500px; text-align: center; margin:auto; font-size: large'>
+            <div data-cy='alert-err-handler' class="alert alert-danger" style="display: none;" role="alert" v-show="errBanner == true" @click="hideBanner">
+                Error Processing Request. This may be an intermittent network issue. Please try again later. 
+            </div>
             <div data-cy='alert-cancel' class="alert alert-danger" style="display: none;" role="alert" v-show="isConfirmed == false">
                 Log submission canceled by user. The log is <strong>NOT</strong> saved.  
             </div>
@@ -206,10 +209,10 @@
                             })    
                             this.isConfirmed = true
                             this.submitInProgress = false
-                            var successBanner = document.getElementById('scrollBanners');
-                            var pageHeader = document.getElementById('navbar');
-                            var headerBounds = pageHeader.getBoundingClientRect();
-                            var alertBounds = successBanner.getBoundingClientRect();
+                            var successBanner = document.getElementById('scrollBanners')
+                            var pageHeader = document.getElementById('navbar')
+                            var headerBounds = pageHeader.getBoundingClientRect()
+                            var alertBounds = successBanner.getBoundingClientRect()
                             scrollBy({
                                 top: alertBounds.top - headerBounds.bottom,
                                 behavior: 'smooth'
@@ -220,8 +223,12 @@
                         })
                         .catch((err) => { 
                             this.errBanner = true
+                            var errorBanner = document.getElementById('scrollBanners')
+                            var pageHeader = document.getElementById('navbar')
+                            var headerBounds = pageHeader.getBoundingClientRect()
+                            var alertBounds = errorBanner.getBoundingClientRect()
                             scrollBy({
-                                top: 0,
+                                top: alertBounds.top - headerBounds.bottom,
                                 behavior: 'smooth'
                             })
                         })
@@ -229,10 +236,10 @@
                 cancelLog() {
                     this.submitInProgress = false
                     this.isConfirmed = false
-                    var cancelBanner = document.getElementById('scrollBanners');
-                    var pageHeader = document.getElementById('navbar');
-                    var headerBounds = pageHeader.getBoundingClientRect();
-                    var alertBounds = cancelBanner.getBoundingClientRect();
+                    var cancelBanner = document.getElementById('scrollBanners')
+                    var pageHeader = document.getElementById('navbar')
+                    var headerBounds = pageHeader.getBoundingClientRect()
+                    var alertBounds = cancelBanner.getBoundingClientRect()
                     scrollBy({
                         top: alertBounds.top - headerBounds.bottom,
                         behavior: 'smooth'
@@ -491,8 +498,12 @@
                         })
                         .catch((err) => { 
                             this.errBanner = true
+                            var errorBanner = document.getElementById('scrollBanners')
+                            var pageHeader = document.getElementById('navbar')
+                            var headerBounds = pageHeader.getBoundingClientRect()
+                            var alertBounds = errorBanner.getBoundingClientRect()
                             scrollBy({
-                                top: 0,
+                                top: alertBounds.top - headerBounds.bottom,
                                 behavior: 'smooth'
                             })
                         })
@@ -505,8 +516,12 @@
                         })
                         .catch((err) => { 
                             this.errBanner = true
+                            var errorBanner = document.getElementById('scrollBanners')
+                            var pageHeader = document.getElementById('navbar')
+                            var headerBounds = pageHeader.getBoundingClientRect()
+                            var alertBounds = errorBanner.getBoundingClientRect()
                             scrollBy({
-                                top: 0,
+                                top: alertBounds.top - headerBounds.bottom,
                                 behavior: 'smooth'
                             })
                         })
@@ -518,8 +533,12 @@
                         })
                         .catch((err) => { 
                             this.errBanner = true
+                            var errorBanner = document.getElementById('scrollBanners')
+                            var pageHeader = document.getElementById('navbar')
+                            var headerBounds = pageHeader.getBoundingClientRect()
+                            var alertBounds = errorBanner.getBoundingClientRect()
                             scrollBy({
-                                top: 0,
+                                top: alertBounds.top - headerBounds.bottom,
                                 behavior: 'smooth'
                             })
                         })
@@ -532,8 +551,13 @@
                         })
                         .catch((err) => { 
                             this.errBanner = true
+                            this.errBanner = true
+                            var errorBanner = document.getElementById('scrollBanners')
+                            var pageHeader = document.getElementById('navbar')
+                            var headerBounds = pageHeader.getBoundingClientRect()
+                            var alertBounds = errorBanner.getBoundingClientRect()
                             scrollBy({
-                                top: 0,
+                                top: alertBounds.top - headerBounds.bottom,
                                 behavior: 'smooth'
                             })
                         })
@@ -544,8 +568,12 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                            var pageHeader = document.getElementById('navbar')
+                            var headerBounds = pageHeader.getBoundingClientRect()
+                            var alertBounds = errorBanner.getBoundingClientRect()
                         scrollBy({
-                            top: 0,
+                            top: alertBounds.top - headerBounds.bottom,
                             behavior: 'smooth'
                         })
                     })
@@ -555,8 +583,12 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                            var pageHeader = document.getElementById('navbar')
+                            var headerBounds = pageHeader.getBoundingClientRect()
+                            var alertBounds = errorBanner.getBoundingClientRect()
                         scrollBy({
-                            top: 0,
+                            top: alertBounds.top - headerBounds.bottom,
                             behavior: 'smooth'
                         })
                     })
@@ -566,8 +598,12 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
                         scrollBy({
-                            top: 0,
+                            top: alertBounds.top - headerBounds.bottom,
                             behavior: 'smooth'
                         })
                     })
@@ -577,8 +613,12 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
                         scrollBy({
-                            top: 0,
+                            top: alertBounds.top - headerBounds.bottom,
                             behavior: 'smooth'
                         })
                     })
@@ -588,8 +628,12 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
                         scrollBy({
-                            top: 0,
+                            top: alertBounds.top - headerBounds.bottom,
                             behavior: 'smooth'
                         })
                     })
@@ -599,8 +643,12 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
                         scrollBy({
-                            top: 0,
+                            top: alertBounds.top - headerBounds.bottom,
                             behavior: 'smooth'
                         })
                     })

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
@@ -1,5 +1,8 @@
 <body>
     <div id='seedingInput'>
+        <div data-cy='alert-err-handler'class="alert alert-danger" style="display: none;" role="alert" v-show="errBanner == true" @click="hideBanner">
+            Error Processing Request. This may be an intermittent network issue. Please try again later. 
+        </div>
         <div class="alert-boxs" style='max-width: 500px; text-align: center; margin:auto; font-size: large'>
             <div data-cy='alert-success' class="alert alert-success" role="alert" v-show="isConfirmed == true">
                 Log created and saved successfully.
@@ -127,7 +130,8 @@
                     "validNumFeet": false,
                 },
                 regPosInt: "^[1-9]+[0-9]*$",
-                regHour:"^[1-9]+[0-9]*([.][0-9]{1,2}){0,1}$|^[0]{0,1}[.][1-9][0-9]{0,1}$|^[0]{0,1}[1-9]$|^[1-9]+[0-9]*\.$"
+                regHour:"^[1-9]+[0-9]*([.][0-9]{1,2}){0,1}$|^[0]{0,1}[.][1-9][0-9]{0,1}$|^[0]{0,1}[1-9]$|^[1-9]+[0-9]*\.$",
+                errBanner: null,
             },
             methods:{
                 updateValidMap(key, bool) {    
@@ -195,18 +199,40 @@
                     this.submitInProgress = true
                 },
                 saveLog() {
-                    createRecord('/farm_asset', this.plantingLogData, this.sessionToken).then((response) => {
-                        this.plantingId = response.data.id
-                    }).then(() => {
-                        createRecord('/log', this.logData, this.sessionToken).then((response) => {
-                            this.clearFields();
-                        })    
-                    })
-                    this.isConfirmed = true
-                    this.submitInProgress = false
-                    setTimeout(() => {
-                        this.isConfirmed = null 
-                    }, 3000)    
+                    createRecord('/farm_asset', this.plantingLogData, this.sessionToken)
+                        .then((response) => {
+                            this.plantingId = response.data.id
+                        })
+                        .then(() => {
+                            createRecord('/log', this.logData, this.sessionToken).then((response) => {
+                                this.clearFields();
+                            })    
+                            this.isConfirmed = true
+                            this.submitInProgress = false
+                            setTimeout(() => {
+                                this.isConfirmed = null 
+                            }, 3000)    
+                        })
+                        .catch((err) => { 
+                            if (err.response) {
+                                // The request was made and the server responded with a status code
+                                // that falls out of the range of 2xx
+                                this.errBanner = true
+                                console.log('Error code that falls out of 2xx.')
+                            } 
+                            else if (err.request) {
+                                // The request was made but no response was received
+                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                                // http.ClientRequest in node.js
+                                this.errBanner = true
+                                console.log('No response was received');
+                            } 
+                            else {
+                                // Something happened in setting up the request that triggered an Error
+                                this.errBanner = true
+                                console.log('Error Message: ', err.message);
+                            }
+                        })
                 },
                 cancelLog() {
                     this.submitInProgress = false
@@ -214,6 +240,9 @@
                     setTimeout(() => { 
                         this.isConfirmed = null
                     }, 3000)
+                },
+                hideBanner(){
+                    this.errBanner = false
                 },
             },
             computed: {
@@ -455,46 +484,256 @@
             created(){
                 let fullResponse = []
                 if(localStorage.getItem('crops') == null){
-                    getAllPages('/taxonomy_term.json?bundle=farm_crops',fullResponse).then(() => {
-                        this.cropArray = fullResponse.map((h) => h.name)
-                        localStorage.setItem('crops', JSON.stringify(this.cropArray))
-                    })
+                    getAllPages('/taxonomy_term.json?bundle=farm_crops',fullResponse)
+                        .then(() => {
+                            this.cropArray = fullResponse.map((h) => h.name)
+                            localStorage.setItem('crops', JSON.stringify(this.cropArray))
+                        })
+                        .catch((err) => { 
+                            if (err.response) {
+                                // The request was made and the server responded with a status code
+                                // that falls out of the range of 2xx
+                                this.errBanner = true
+                                console.log('Error code that falls out of 2xx.')
+                            } 
+                            else if (err.request) {
+                                // The request was made but no response was received
+                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                                // http.ClientRequest in node.js
+                                this.errBanner = true
+                                console.log('No response was received');
+                            } 
+                            else {
+                                // Something happened in setting up the request that triggered an Error
+                                this.errBanner = true
+                                console.log('Error Message: ', err.message);
+                            }
+                        })
                 }else{
                     this.cropArray = JSON.parse(localStorage.getItem('crops'))
-                    getAllPages('/taxonomy_term.json?bundle=farm_crops',fullResponse).then(() => {
-                        this.cropArray = fullResponse.map((h) => h.name)
-                        localStorage.setItem('crops', JSON.stringify(this.cropArray))
-                    })
+                    getAllPages('/taxonomy_term.json?bundle=farm_crops',fullResponse)
+                        .then(() => {
+                            this.cropArray = fullResponse.map((h) => h.name)
+                            localStorage.setItem('crops', JSON.stringify(this.cropArray))
+                        })
+                        .catch((err) => { 
+                            if (err.response) {
+                                // The request was made and the server responded with a status code
+                                // that falls out of the range of 2xx
+                                this.errBanner = true
+                                console.log('Error code that falls out of 2xx.')
+                            } 
+                            else if (err.request) {
+                                // The request was made but no response was received
+                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                                // http.ClientRequest in node.js
+                                this.errBanner = true
+                                console.log('No response was received');
+                            } 
+                            else {
+                                // Something happened in setting up the request that triggered an Error
+                                this.errBanner = true
+                                console.log('Error Message: ', err.message);
+                            }
+                        })
                 }
                 if(localStorage.getItem('areas') == null){
-                    getAllPages('/taxonomy_term.json?bundle=farm_areas', this.areaResponse).then(() => {
-                        localStorage.setItem('areas', JSON.stringify(this.areaResponse))
+                    getAllPages('/taxonomy_term.json?bundle=farm_areas', this.areaResponse)
+                        .then(() => {
+                            localStorage.setItem('areas', JSON.stringify(this.areaResponse))
+                        })
+                        .catch((err) => { 
+                        if (err.response) {
+                            // The request was made and the server responded with a status code
+                            // that falls out of the range of 2xx
+                            this.errBanner = true
+                            console.log('Error code that falls out of 2xx.')
+                        } 
+                        else if (err.request) {
+                            // The request was made but no response was received
+                            // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                            // http.ClientRequest in node.js
+                            this.errBanner = true
+                            console.log('No response was received');
+                        } 
+                        else {
+                            // Something happened in setting up the request that triggered an Error
+                            this.errBanner = true
+                            console.log('Error Message: ', err.message);
+                        }
                     })
                 }else{
                     this.areaResponse = JSON.parse(localStorage.getItem('areas'))
-                    getAllPages('/taxonomy_term.json?bundle=farm_areas').then((resp) => {
-                        this.areaResponse = resp
-                        localStorage.setItem('areas', JSON.stringify(resp))
-                    })
+                    getAllPages('/taxonomy_term.json?bundle=farm_areas')
+                        .then((resp) => {
+                            this.areaResponse = resp
+                            localStorage.setItem('areas', JSON.stringify(resp))
+                        })
+                        .catch((err) => { 
+                            if (err.response) {
+                                // The request was made and the server responded with a status code
+                                // that falls out of the range of 2xx
+                                this.errBanner = true
+                                console.log('Error code that falls out of 2xx.')
+                            } 
+                            else if (err.request) {
+                                // The request was made but no response was received
+                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                                // http.ClientRequest in node.js
+                                this.errBanner = true
+                                console.log('No response was received');
+                            } 
+                            else {
+                                // Something happened in setting up the request that triggered an Error
+                                this.errBanner = true
+                                console.log('Error Message: ', err.message);
+                            }
+                        })
                 }
-                getSessionToken().then((response) => {
-                    this.sessionToken = response
-                })
-                getCropToIDMap().then((response) => {
-                    this.cropToIDMap = response
-                })
-                getUserToIDMap().then((response) => {
-                    this.userToIDMap = response
-                })
-                getAreaToIDMap().then((response) => {
-                    this.areaToIDMap = response
-                })
-                getUnitToIDMap().then((response) => {
-                    this.unitToIDMap = response
-                })
-                getLogTypeToIDMap().then((response) => {
-                    this.logTypeToIDMap = response
-                })
+                getSessionToken()
+                    .then((response) => {
+                        this.sessionToken = response
+                    })
+                    .catch((err) => { 
+                            if (err.response) {
+                                // The request was made and the server responded with a status code
+                                // that falls out of the range of 2xx
+                                this.errBanner = true
+                                console.log('Error code that falls out of 2xx.')
+                            } 
+                            else if (err.request) {
+                                // The request was made but no response was received
+                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                                // http.ClientRequest in node.js
+                                this.errBanner = true
+                                console.log('No response was received');
+                            } 
+                            else {
+                                // Something happened in setting up the request that triggered an Error
+                                this.errBanner = true
+                                console.log('Error Message: ', err.message);
+                            }
+                        })
+                getCropToIDMap()
+                    .then((response) => {
+                        this.cropToIDMap = response
+                    })
+                    .catch((err) => { 
+                            if (err.response) {
+                                // The request was made and the server responded with a status code
+                                // that falls out of the range of 2xx
+                                this.errBanner = true
+                                console.log('Error code that falls out of 2xx.')
+                            } 
+                            else if (err.request) {
+                                // The request was made but no response was received
+                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                                // http.ClientRequest in node.js
+                                this.errBanner = true
+                                console.log('No response was received');
+                            } 
+                            else {
+                                // Something happened in setting up the request that triggered an Error
+                                this.errBanner = true
+                                console.log('Error Message: ', err.message);
+                            }
+                        })
+                getUserToIDMap()
+                    .then((response) => {
+                        this.userToIDMap = response
+                    })
+                    .catch((err) => { 
+                            if (err.response) {
+                                // The request was made and the server responded with a status code
+                                // that falls out of the range of 2xx
+                                this.errBanner = true
+                                console.log('Error code that falls out of 2xx.')
+                            } 
+                            else if (err.request) {
+                                // The request was made but no response was received
+                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                                // http.ClientRequest in node.js
+                                this.errBanner = true
+                                console.log('No response was received');
+                            } 
+                            else {
+                                // Something happened in setting up the request that triggered an Error
+                                this.errBanner = true
+                                console.log('Error Message: ', err.message);
+                            }
+                        })
+                getAreaToIDMap()
+                    .then((response) => {
+                        this.areaToIDMap = response
+                    })
+                    .catch((err) => { 
+                            if (err.response) {
+                                // The request was made and the server responded with a status code
+                                // that falls out of the range of 2xx
+                                this.errBanner = true
+                                console.log('Error code that falls out of 2xx.')
+                            } 
+                            else if (err.request) {
+                                // The request was made but no response was received
+                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                                // http.ClientRequest in node.js
+                                this.errBanner = true
+                                console.log('No response was received');
+                            } 
+                            else {
+                                // Something happened in setting up the request that triggered an Error
+                                this.errBanner = true
+                                console.log('Error Message: ', err.message);
+                            }
+                        })
+                getUnitToIDMap()
+                    .then((response) => {
+                        this.unitToIDMap = response
+                    })
+                    .catch((err) => { 
+                            if (err.response) {
+                                // The request was made and the server responded with a status code
+                                // that falls out of the range of 2xx
+                                this.errBanner = true
+                                console.log('Error code that falls out of 2xx.')
+                            } 
+                            else if (err.request) {
+                                // The request was made but no response was received
+                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                                // http.ClientRequest in node.js
+                                this.errBanner = true
+                                console.log('No response was received');
+                            } 
+                            else {
+                                // Something happened in setting up the request that triggered an Error
+                                this.errBanner = true
+                                console.log('Error Message: ', err.message);
+                            }
+                        })
+                getLogTypeToIDMap()
+                    .then((response) => {
+                        this.logTypeToIDMap = response
+                    })
+                    .catch((err) => { 
+                            if (err.response) {
+                                // The request was made and the server responded with a status code
+                                // that falls out of the range of 2xx
+                                this.errBanner = true
+                                console.log('Error code that falls out of 2xx.')
+                            } 
+                            else if (err.request) {
+                                // The request was made but no response was received
+                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                                // http.ClientRequest in node.js
+                                this.errBanner = true
+                                console.log('No response was received');
+                            } 
+                            else {
+                                // Something happened in setting up the request that triggered an Error
+                                this.errBanner = true
+                                console.log('Error Message: ', err.message);
+                            }
+                        })
             }
         })
         Vue.config.devtools = true;

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
@@ -19,7 +19,7 @@
             </div>
         </fieldset>
         <fieldset class="panel panel-default center-block" style="max-width: 500px;">
-           <legend class="panel-heading" style='background-color: #da4f3f; color: white;font-size: x-large;'>
+            <legend class="panel-heading" style='background-color: #da4f3f; color: white;font-size: x-large;'>
                 <input data-cy='tray-seedings' type='radio' name='typeOfSeeding' value='Tray Seedings' v-model='selectedSeedingType' :checked='selectedSeedingType == "Tray Seedings"' v-bind:disabled='submitInProgress'><label>Tray &nbsp;</label>
                 <input data-cy='direct-seedings' type='radio' name='typeOfSeeding' value='Direct Seedings'v-model='selectedSeedingType' :checked='selectedSeedingType == "Direct Seedings"' v-bind:disabled='submitInProgress'><label>Direct</label> 
             </legend>

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
@@ -214,15 +214,7 @@
                             }, 3000)    
                         })
                         .catch((err) => { 
-                            if (err.response) {
-                                this.errBanner = true
-                            } 
-                            else if (err.request) {
-                                this.errBanner = true
-                            } 
-                            else {
-                                this.errBanner = true
-                            }
+                            this.errBanner = true
                             scrollTo({
                                 top: 0,
                                 behavior: 'smooth'
@@ -528,15 +520,7 @@
                             localStorage.setItem('areas', JSON.stringify(this.areaResponse))
                         })
                         .catch((err) => { 
-                            if (err.response) {
-                                this.errBanner = true
-                            } 
-                            else if (err.request) {
-                                this.errBanner = true
-                            } 
-                            else {
-                                this.errBanner = true
-                            }
+                            this.errBanner = true
                             scrollTo({
                                 top: 0,
                                 behavior: 'smooth'
@@ -550,19 +534,11 @@
                             localStorage.setItem('areas', JSON.stringify(resp))
                         })
                         .catch((err) => { 
-                            if (err.response) {
-                                this.errBanner = true
-                            } 
-                            else if (err.request) {
-                                this.errBanner = true
-                            } 
-                            else {
-                                this.errBanner = true
-                            }
+                            this.errBanner = true
                             scrollTo({
-                            top: 0,
-                            behavior: 'smooth'
-                        })
+                                top: 0,
+                                behavior: 'smooth'
+                            })
                         })
                 }
                 getSessionToken()
@@ -570,15 +546,7 @@
                         this.sessionToken = response
                     })
                     .catch((err) => { 
-                        if (err.response) {
-                            this.errBanner = true
-                        } 
-                        else if (err.request) {
-                            this.errBanner = true
-                        } 
-                        else {
-                            this.errBanner = true
-                        }
+                        this.errBanner = true
                         scrollTo({
                             top: 0,
                             behavior: 'smooth'
@@ -589,15 +557,7 @@
                         this.cropToIDMap = response
                     })
                     .catch((err) => { 
-                        if (err.response) {
-                            this.errBanner = true
-                        } 
-                        else if (err.request) {
-                            this.errBanner = true
-                        } 
-                        else {
-                            this.errBanner = true
-                        }
+                        this.errBanner = true
                         scrollTo({
                             top: 0,
                             behavior: 'smooth'
@@ -608,15 +568,7 @@
                         this.userToIDMap = response
                     })
                     .catch((err) => { 
-                        if (err.response) {
-                            this.errBanner = true
-                        } 
-                        else if (err.request) {
-                            this.errBanner = true
-                        } 
-                        else {
-                            this.errBanner = true
-                        }
+                        this.errBanner = true
                         scrollTo({
                             top: 0,
                             behavior: 'smooth'
@@ -627,15 +579,7 @@
                         this.areaToIDMap = response
                     })
                     .catch((err) => { 
-                        if (err.response) {
-                            this.errBanner = true
-                        } 
-                        else if (err.request) {
-                            this.errBanner = true
-                        } 
-                        else {
-                            this.errBanner = true
-                        }
+                        this.errBanner = true
                         scrollTo({
                             top: 0,
                             behavior: 'smooth'
@@ -646,15 +590,7 @@
                         this.unitToIDMap = response
                     })
                     .catch((err) => { 
-                        if (err.response) {
-                            this.errBanner = true
-                        } 
-                        else if (err.request) {
-                            this.errBanner = true
-                        } 
-                        else {
-                            this.errBanner = true
-                        }
+                        this.errBanner = true
                         scrollTo({
                             top: 0,
                             behavior: 'smooth'
@@ -665,15 +601,7 @@
                         this.logTypeToIDMap = response
                     })
                     .catch((err) => { 
-                        if (err.response) {
-                            this.errBanner = true
-                        } 
-                        else if (err.request) {
-                            this.errBanner = true
-                        } 
-                        else {
-                            this.errBanner = true
-                        }
+                        this.errBanner = true
                         scrollTo({
                             top: 0,
                             behavior: 'smooth'

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
@@ -477,15 +477,7 @@
                             localStorage.setItem('crops', JSON.stringify(this.cropArray))
                         })
                         .catch((err) => { 
-                            if (err.response) {
-                                this.errBanner = true
-                            } 
-                            else if (err.request) {
-                                this.errBanner = true
-                            } 
-                            else {
-                                this.errBanner = true
-                            }
+                            this.errBanner = true
                             scrollTo({
                                 top: 0,
                                 behavior: 'smooth'
@@ -499,15 +491,7 @@
                             localStorage.setItem('crops', JSON.stringify(this.cropArray))
                         })
                         .catch((err) => { 
-                            if (err.response) {
-                                this.errBanner = true
-                            } 
-                            else if (err.request) {
-                                this.errBanner = true
-                            } 
-                            else {
-                                this.errBanner = true
-                            }
+                            this.errBanner = true
                             scrollTo({
                                 top: 0,
                                 behavior: 'smooth'

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
@@ -1,18 +1,10 @@
 <body>
     <div id='seedingInput'>
-<<<<<<< HEAD
-        <div data-cy='alert-err-handler'class="alert alert-danger" style="display: none;" role="alert" v-show="errBanner == true" @click="hideBanner">
-            Error Processing Request. This may be an intermittent network issue. Please try again later. 
-        </div>
-        <div class="alert-boxs" style='max-width: 500px; text-align: center; margin:auto; font-size: large'>
-=======
-
         <h1 style='text-align:center;'>Seeding Input Log</h1> 
         <div data-cy="alert-container" id="scrollBanners" class="alert-boxs" style='max-width: 500px; text-align: center; margin:auto; font-size: large'>
             <div data-cy='alert-cancel' class="alert alert-danger" style="display: none;" role="alert" v-show="isConfirmed == false">
                 Log submission canceled by user. The log is <strong>NOT</strong> saved.  
             </div>
->>>>>>> main
             <div data-cy='alert-success' class="alert alert-success" role="alert" v-show="isConfirmed == true">
                 Log created and saved successfully.
             </div>
@@ -228,7 +220,7 @@
                         })
                         .catch((err) => { 
                             this.errBanner = true
-                            scrollTo({
+                            scrollBy({
                                 top: 0,
                                 behavior: 'smooth'
                             })
@@ -499,7 +491,7 @@
                         })
                         .catch((err) => { 
                             this.errBanner = true
-                            scrollTo({
+                            scrollBy({
                                 top: 0,
                                 behavior: 'smooth'
                             })
@@ -513,7 +505,7 @@
                         })
                         .catch((err) => { 
                             this.errBanner = true
-                            scrollTo({
+                            scrollBy({
                                 top: 0,
                                 behavior: 'smooth'
                             })
@@ -526,7 +518,7 @@
                         })
                         .catch((err) => { 
                             this.errBanner = true
-                            scrollTo({
+                            scrollBy({
                                 top: 0,
                                 behavior: 'smooth'
                             })
@@ -540,7 +532,7 @@
                         })
                         .catch((err) => { 
                             this.errBanner = true
-                            scrollTo({
+                            scrollBy({
                                 top: 0,
                                 behavior: 'smooth'
                             })
@@ -552,7 +544,7 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
-                        scrollTo({
+                        scrollBy({
                             top: 0,
                             behavior: 'smooth'
                         })
@@ -563,7 +555,7 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
-                        scrollTo({
+                        scrollBy({
                             top: 0,
                             behavior: 'smooth'
                         })
@@ -574,7 +566,7 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
-                        scrollTo({
+                        scrollBy({
                             top: 0,
                             behavior: 'smooth'
                         })
@@ -585,7 +577,7 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
-                        scrollTo({
+                        scrollBy({
                             top: 0,
                             behavior: 'smooth'
                         })
@@ -596,7 +588,7 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
-                        scrollTo({
+                        scrollBy({
                             top: 0,
                             behavior: 'smooth'
                         })
@@ -607,7 +599,7 @@
                     })
                     .catch((err) => { 
                         this.errBanner = true
-                        scrollTo({
+                        scrollBy({
                             top: 0,
                             behavior: 'smooth'
                         })

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
@@ -215,22 +215,13 @@
                         })
                         .catch((err) => { 
                             if (err.response) {
-                                // The request was made and the server responded with a status code
-                                // that falls out of the range of 2xx
                                 this.errBanner = true
-                                console.log('Error code that falls out of 2xx.')
                             } 
                             else if (err.request) {
-                                // The request was made but no response was received
-                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-                                // http.ClientRequest in node.js
                                 this.errBanner = true
-                                console.log('No response was received');
                             } 
                             else {
-                                // Something happened in setting up the request that triggered an Error
                                 this.errBanner = true
-                                console.log('Error Message: ', err.message);
                             }
                         })
                 },
@@ -491,22 +482,13 @@
                         })
                         .catch((err) => { 
                             if (err.response) {
-                                // The request was made and the server responded with a status code
-                                // that falls out of the range of 2xx
                                 this.errBanner = true
-                                console.log('Error code that falls out of 2xx.')
                             } 
                             else if (err.request) {
-                                // The request was made but no response was received
-                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-                                // http.ClientRequest in node.js
                                 this.errBanner = true
-                                console.log('No response was received');
                             } 
                             else {
-                                // Something happened in setting up the request that triggered an Error
                                 this.errBanner = true
-                                console.log('Error Message: ', err.message);
                             }
                         })
                 }else{
@@ -518,22 +500,13 @@
                         })
                         .catch((err) => { 
                             if (err.response) {
-                                // The request was made and the server responded with a status code
-                                // that falls out of the range of 2xx
                                 this.errBanner = true
-                                console.log('Error code that falls out of 2xx.')
                             } 
                             else if (err.request) {
-                                // The request was made but no response was received
-                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-                                // http.ClientRequest in node.js
                                 this.errBanner = true
-                                console.log('No response was received');
                             } 
                             else {
-                                // Something happened in setting up the request that triggered an Error
                                 this.errBanner = true
-                                console.log('Error Message: ', err.message);
                             }
                         })
                 }
@@ -543,25 +516,16 @@
                             localStorage.setItem('areas', JSON.stringify(this.areaResponse))
                         })
                         .catch((err) => { 
-                        if (err.response) {
-                            // The request was made and the server responded with a status code
-                            // that falls out of the range of 2xx
-                            this.errBanner = true
-                            console.log('Error code that falls out of 2xx.')
-                        } 
-                        else if (err.request) {
-                            // The request was made but no response was received
-                            // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-                            // http.ClientRequest in node.js
-                            this.errBanner = true
-                            console.log('No response was received');
-                        } 
-                        else {
-                            // Something happened in setting up the request that triggered an Error
-                            this.errBanner = true
-                            console.log('Error Message: ', err.message);
-                        }
-                    })
+                            if (err.response) {
+                                this.errBanner = true
+                            } 
+                            else if (err.request) {
+                                this.errBanner = true
+                            } 
+                            else {
+                                this.errBanner = true
+                            }
+                        })
                 }else{
                     this.areaResponse = JSON.parse(localStorage.getItem('areas'))
                     getAllPages('/taxonomy_term.json?bundle=farm_areas')
@@ -571,22 +535,13 @@
                         })
                         .catch((err) => { 
                             if (err.response) {
-                                // The request was made and the server responded with a status code
-                                // that falls out of the range of 2xx
                                 this.errBanner = true
-                                console.log('Error code that falls out of 2xx.')
                             } 
                             else if (err.request) {
-                                // The request was made but no response was received
-                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-                                // http.ClientRequest in node.js
                                 this.errBanner = true
-                                console.log('No response was received');
                             } 
                             else {
-                                // Something happened in setting up the request that triggered an Error
                                 this.errBanner = true
-                                console.log('Error Message: ', err.message);
                             }
                         })
                 }
@@ -595,145 +550,91 @@
                         this.sessionToken = response
                     })
                     .catch((err) => { 
-                            if (err.response) {
-                                // The request was made and the server responded with a status code
-                                // that falls out of the range of 2xx
-                                this.errBanner = true
-                                console.log('Error code that falls out of 2xx.')
-                            } 
-                            else if (err.request) {
-                                // The request was made but no response was received
-                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-                                // http.ClientRequest in node.js
-                                this.errBanner = true
-                                console.log('No response was received');
-                            } 
-                            else {
-                                // Something happened in setting up the request that triggered an Error
-                                this.errBanner = true
-                                console.log('Error Message: ', err.message);
-                            }
-                        })
+                        if (err.response) {
+                            this.errBanner = true
+                        } 
+                        else if (err.request) {
+                            this.errBanner = true
+                        } 
+                        else {
+                            this.errBanner = true
+                        }
+                    })
                 getCropToIDMap()
                     .then((response) => {
                         this.cropToIDMap = response
                     })
                     .catch((err) => { 
-                            if (err.response) {
-                                // The request was made and the server responded with a status code
-                                // that falls out of the range of 2xx
-                                this.errBanner = true
-                                console.log('Error code that falls out of 2xx.')
-                            } 
-                            else if (err.request) {
-                                // The request was made but no response was received
-                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-                                // http.ClientRequest in node.js
-                                this.errBanner = true
-                                console.log('No response was received');
-                            } 
-                            else {
-                                // Something happened in setting up the request that triggered an Error
-                                this.errBanner = true
-                                console.log('Error Message: ', err.message);
-                            }
-                        })
+                        if (err.response) {
+                            this.errBanner = true
+                        } 
+                        else if (err.request) {
+                            this.errBanner = true
+                        } 
+                        else {
+                            this.errBanner = true
+                        }
+                    })
                 getUserToIDMap()
                     .then((response) => {
                         this.userToIDMap = response
                     })
                     .catch((err) => { 
-                            if (err.response) {
-                                // The request was made and the server responded with a status code
-                                // that falls out of the range of 2xx
-                                this.errBanner = true
-                                console.log('Error code that falls out of 2xx.')
-                            } 
-                            else if (err.request) {
-                                // The request was made but no response was received
-                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-                                // http.ClientRequest in node.js
-                                this.errBanner = true
-                                console.log('No response was received');
-                            } 
-                            else {
-                                // Something happened in setting up the request that triggered an Error
-                                this.errBanner = true
-                                console.log('Error Message: ', err.message);
-                            }
-                        })
+                        if (err.response) {
+                            this.errBanner = true
+                        } 
+                        else if (err.request) {
+                            this.errBanner = true
+                        } 
+                        else {
+                            this.errBanner = true
+                        }
+                    })
                 getAreaToIDMap()
                     .then((response) => {
                         this.areaToIDMap = response
                     })
                     .catch((err) => { 
-                            if (err.response) {
-                                // The request was made and the server responded with a status code
-                                // that falls out of the range of 2xx
-                                this.errBanner = true
-                                console.log('Error code that falls out of 2xx.')
-                            } 
-                            else if (err.request) {
-                                // The request was made but no response was received
-                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-                                // http.ClientRequest in node.js
-                                this.errBanner = true
-                                console.log('No response was received');
-                            } 
-                            else {
-                                // Something happened in setting up the request that triggered an Error
-                                this.errBanner = true
-                                console.log('Error Message: ', err.message);
-                            }
-                        })
+                        if (err.response) {
+                            this.errBanner = true
+                        } 
+                        else if (err.request) {
+                            this.errBanner = true
+                        } 
+                        else {
+                            this.errBanner = true
+                        }
+                    })
                 getUnitToIDMap()
                     .then((response) => {
                         this.unitToIDMap = response
                     })
                     .catch((err) => { 
-                            if (err.response) {
-                                // The request was made and the server responded with a status code
-                                // that falls out of the range of 2xx
-                                this.errBanner = true
-                                console.log('Error code that falls out of 2xx.')
-                            } 
-                            else if (err.request) {
-                                // The request was made but no response was received
-                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-                                // http.ClientRequest in node.js
-                                this.errBanner = true
-                                console.log('No response was received');
-                            } 
-                            else {
-                                // Something happened in setting up the request that triggered an Error
-                                this.errBanner = true
-                                console.log('Error Message: ', err.message);
-                            }
-                        })
+                        if (err.response) {
+                            this.errBanner = true
+                        } 
+                        else if (err.request) {
+                            this.errBanner = true
+                        } 
+                        else {
+                            this.errBanner = true
+                        }
+                    })
                 getLogTypeToIDMap()
                     .then((response) => {
                         this.logTypeToIDMap = response
                     })
                     .catch((err) => { 
-                            if (err.response) {
-                                // The request was made and the server responded with a status code
-                                // that falls out of the range of 2xx
-                                this.errBanner = true
-                                console.log('Error code that falls out of 2xx.')
-                            } 
-                            else if (err.request) {
-                                // The request was made but no response was received
-                                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-                                // http.ClientRequest in node.js
-                                this.errBanner = true
-                                console.log('No response was received');
-                            } 
-                            else {
-                                // Something happened in setting up the request that triggered an Error
-                                this.errBanner = true
-                                console.log('Error Message: ', err.message);
-                            }
-                        })
+                        if (err.response) {
+                            this.errBanner = true
+                        } 
+                        else if (err.request) {
+                            this.errBanner = true
+                        } 
+                        else {
+                            this.errBanner = true
+                        }
+                    })
             }
         })
         Vue.config.devtools = true;

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
@@ -223,6 +223,10 @@
                             else {
                                 this.errBanner = true
                             }
+                            scrollTo({
+                                top: 0,
+                                behavior: 'smooth'
+                            })
                         })
                 },
                 cancelLog() {
@@ -490,6 +494,10 @@
                             else {
                                 this.errBanner = true
                             }
+                            scrollTo({
+                                top: 0,
+                                behavior: 'smooth'
+                            })
                         })
                 }else{
                     this.cropArray = JSON.parse(localStorage.getItem('crops'))
@@ -508,6 +516,10 @@
                             else {
                                 this.errBanner = true
                             }
+                            scrollTo({
+                                top: 0,
+                                behavior: 'smooth'
+                            })
                         })
                 }
                 if(localStorage.getItem('areas') == null){
@@ -525,6 +537,10 @@
                             else {
                                 this.errBanner = true
                             }
+                            scrollTo({
+                                top: 0,
+                                behavior: 'smooth'
+                            })
                         })
                 }else{
                     this.areaResponse = JSON.parse(localStorage.getItem('areas'))
@@ -543,6 +559,10 @@
                             else {
                                 this.errBanner = true
                             }
+                            scrollTo({
+                            top: 0,
+                            behavior: 'smooth'
+                        })
                         })
                 }
                 getSessionToken()
@@ -559,6 +579,10 @@
                         else {
                             this.errBanner = true
                         }
+                        scrollTo({
+                            top: 0,
+                            behavior: 'smooth'
+                        })
                     })
                 getCropToIDMap()
                     .then((response) => {
@@ -574,6 +598,10 @@
                         else {
                             this.errBanner = true
                         }
+                        scrollTo({
+                            top: 0,
+                            behavior: 'smooth'
+                        })
                     })
                 getUserToIDMap()
                     .then((response) => {
@@ -589,6 +617,10 @@
                         else {
                             this.errBanner = true
                         }
+                        scrollTo({
+                            top: 0,
+                            behavior: 'smooth'
+                        })
                     })
                 getAreaToIDMap()
                     .then((response) => {
@@ -604,6 +636,10 @@
                         else {
                             this.errBanner = true
                         }
+                        scrollTo({
+                            top: 0,
+                            behavior: 'smooth'
+                        })
                     })
                 getUnitToIDMap()
                     .then((response) => {
@@ -619,6 +655,10 @@
                         else {
                             this.errBanner = true
                         }
+                        scrollTo({
+                            top: 0,
+                            behavior: 'smooth'
+                        })
                     })
                 getLogTypeToIDMap()
                     .then((response) => {
@@ -634,6 +674,10 @@
                         else {
                             this.errBanner = true
                         }
+                        scrollTo({
+                            top: 0,
+                            behavior: 'smooth'
+                        })
                     })
             }
         })

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.spec.js
@@ -1451,7 +1451,7 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
-                    cy.window().its('scrollY').should('equal', 0)
+                    cy.window().its('scrollY').should('equal', 300)
                     cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
@@ -1490,7 +1490,7 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
-                    cy.window().its('scrollY').should('equal', 0)
+                    cy.window().its('scrollY').should('equal', 300)
                     cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
@@ -1512,7 +1512,7 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
-                    cy.window().its('scrollY').should('equal', 0)
+                    cy.window().its('scrollY').should('equal', 300)
                     cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
@@ -1527,7 +1527,7 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
-                    cy.window().its('scrollY').should('equal', 0)
+                    cy.window().its('scrollY').should('equal', 300)
                     cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
@@ -1547,7 +1547,7 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
-                    cy.window().its('scrollY').should('equal', 0)
+                    cy.window().its('scrollY').should('equal', 300)
                     cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
@@ -1562,7 +1562,7 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
-                    cy.window().its('scrollY').should('equal', 0)
+                    cy.window().its('scrollY').should('equal', 300)
                     cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
@@ -1582,7 +1582,7 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
-                    cy.window().its('scrollY').should('equal', 0)
+                    cy.window().its('scrollY').should('equal', 300)
                     cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
@@ -1597,7 +1597,7 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
-                    cy.window().its('scrollY').should('equal', 0)
+                    cy.window().its('scrollY').should('equal', 300)
                     cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
@@ -1617,7 +1617,7 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
-                    cy.window().its('scrollY').should('equal', 0)
+                    cy.window().its('scrollY').should('equal', 300)
                     cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
@@ -1632,7 +1632,7 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
-                    cy.window().its('scrollY').should('equal', 0)
+                    cy.window().its('scrollY').should('equal', 300)
                     cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
@@ -1652,7 +1652,7 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
-                    cy.window().its('scrollY').should('equal', 0)
+                    cy.window().its('scrollY').should('equal', 300)
                     cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
@@ -1667,7 +1667,7 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
-                    cy.window().its('scrollY').should('equal', 0)
+                    cy.window().its('scrollY').should('equal', 300)
                     cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
@@ -1688,7 +1688,7 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
-                    cy.window().its('scrollY').should('equal', 0)
+                    cy.window().its('scrollY').should('equal', 300)
                     cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
@@ -1704,7 +1704,7 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
-                    cy.window().its('scrollY').should('equal', 0)
+                    cy.window().its('scrollY').should('equal', 300)
                     cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.spec.js
@@ -1658,7 +1658,6 @@ describe('Test the seeding input page', () => {
                 }) 
         })
 
-
         it('fail the log type map API: network error', () => {
             cy.login('manager1', 'farmdata2')
             cy.intercept('GET', 'taxonomy_term.json?bundle=farm_log_categories', { forceNetworkError: true }).as('failedLogTypeMap')
@@ -1676,8 +1675,6 @@ describe('Test the seeding input page', () => {
         // if something else happens while setting up the request
         // then it would also be handled here. 
         // it('fail the log type map API: something happened that triggered an error', () => {
-        // })
-
-        
+        // })   
     })
 })

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.spec.js
@@ -1440,6 +1440,8 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 })
@@ -1477,6 +1479,8 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 })
@@ -1497,6 +1501,8 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 
@@ -1510,6 +1516,8 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 
@@ -1528,6 +1536,8 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 
@@ -1541,6 +1551,8 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 
@@ -1559,6 +1571,8 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 
@@ -1572,6 +1586,8 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 
@@ -1590,6 +1606,8 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 
@@ -1603,6 +1621,8 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 
@@ -1621,6 +1641,8 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 
@@ -1634,6 +1656,8 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 
@@ -1653,6 +1677,8 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 
@@ -1667,6 +1693,8 @@ describe('Test the seeding input page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
                 }) 


### PR DESCRIPTION
__Pull Request Description__

This PR aims to solve #360 by implementing a standard for pages to handle API request failures. 
When an API request fails, a banner will appear on the top of the page to indicate to the user that an API request has failed and to attempt to revisit the page shortly. 

**Note: This PR is ready to be merged into upstream**
The following steps must be completed before this PR is ready for review:
- [x] An example should be built and tested on the UI sub-tab of the FD2 Example tab.
- [x] The approach should be added into all of the API calls on FieldKit tab with tests.
- [x] The approach should be added into all of the API calls on BarnKit tab with tests.
- [x] The approach should be added into all of the API calls on FD2 Config tab with tests.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
