### PR TITLE
Seeding Input: Auto Scrolls to Banners at the Top of Page

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
@@ -220,7 +220,6 @@
                 cancelLog() {
                     this.submitInProgress = false
                     this.isConfirmed = false
-                    console.log("Caneled")
                     var cancelBanner = document.getElementById('scrollBanners');
                     var pageHeader = document.getElementById('navbar');
                     var headerBounds = pageHeader.getBoundingClientRect();

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
@@ -1,6 +1,8 @@
 <body>
     <div id='seedingInput'>
-        <div data-cy="alert-container" class="alert-boxs" style='max-width: 500px; text-align: center; margin:auto; font-size: large'>
+
+        <h1 style='text-align:center;'>Seeding Input Log</h1> 
+        <div data-cy="alert-container" id="scrollBanners" class="alert-boxs" style='max-width: 500px; text-align: center; margin:auto; font-size: large'>
             <div data-cy='alert-cancel' class="alert alert-danger" style="display: none;" role="alert" v-show="isConfirmed == false">
                 Log submission canceled by user. The log is <strong>NOT</strong> saved.  
             </div>
@@ -8,7 +10,6 @@
                 Log created and saved successfully.
             </div>
         </div>
-        <h1 style='text-align:center;'>Seeding Input Log</h1> 
         <br>
         <fieldset class="panel panel-default center-block" style='max-width: 500px;'>
             <legend class="panel-heading" style='background-color: #da4f3f; color: white;font-size: x-large;'>Data</legend>
@@ -204,10 +205,14 @@
                     })
                     this.isConfirmed = true
                     this.submitInProgress = false
+                    var successBanner = document.getElementById('scrollBanners');
+                    var pageHeader = document.getElementById('navbar');
+                    var headerBounds = pageHeader.getBoundingClientRect();
+                    var alertBounds = successBanner.getBoundingClientRect();
                     scrollTo({
-                        top: 230,
+                        top: (-(alertBounds.bottom) - headerBounds.bottom),
                         behavior: 'smooth'
-                    });
+                    })
                     setTimeout(() => { 
                         this.isConfirmed = null
                     }, 3000)   
@@ -215,10 +220,15 @@
                 cancelLog() {
                     this.submitInProgress = false
                     this.isConfirmed = false
+                    console.log("Caneled")
+                    var cancelBanner = document.getElementById('scrollBanners');
+                    var pageHeader = document.getElementById('navbar');
+                    var headerBounds = pageHeader.getBoundingClientRect();
+                    var alertBounds = cancelBanner.getBoundingClientRect();
                     scrollTo({
-                        top: 230,
+                        top: (-(alertBounds.bottom) - headerBounds.bottom),
                         behavior: 'smooth'
-                    });
+                    })
                     setTimeout(() => { 
                         this.isConfirmed = null
                     }, 3000)

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
@@ -209,8 +209,8 @@
                     var pageHeader = document.getElementById('navbar');
                     var headerBounds = pageHeader.getBoundingClientRect();
                     var alertBounds = successBanner.getBoundingClientRect();
-                    scrollTo({
-                        top: (-(alertBounds.bottom) - headerBounds.bottom),
+                    scrollBy({
+                        top: alertBounds.top - headerBounds.bottom,
                         behavior: 'smooth'
                     })
                     setTimeout(() => { 
@@ -225,8 +225,8 @@
                     var pageHeader = document.getElementById('navbar');
                     var headerBounds = pageHeader.getBoundingClientRect();
                     var alertBounds = cancelBanner.getBoundingClientRect();
-                    scrollTo({
-                        top: (-(alertBounds.bottom) - headerBounds.bottom),
+                    scrollBy({
+                        top: alertBounds.top - headerBounds.bottom,
                         behavior: 'smooth'
                     })
                     setTimeout(() => { 

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
@@ -1,6 +1,6 @@
 <body>
     <div id='seedingInput'>
-        <div data-cy="alert-container" id="scrollBanners" class="alert-boxs" style='max-width: 500px; text-align: center; margin:auto; font-size: large'>
+        <div data-cy="alert-container" class="alert-boxs" style='max-width: 500px; text-align: center; margin:auto; font-size: large'>
             <div data-cy='alert-cancel' class="alert alert-danger" style="display: none;" role="alert" v-show="isConfirmed == false">
                 Log submission canceled by user. The log is <strong>NOT</strong> saved.  
             </div>
@@ -204,17 +204,21 @@
                     })
                     this.isConfirmed = true
                     this.submitInProgress = false
-                    var confirmBanner = document.getElementById('scrollBanners');
-                    confirmBanner.scrollIntoView(false);
-                    setTimeout(() => {
-                        this.isConfirmed = null 
-                    }, 3000)    
+                    scrollTo({
+                        top: 230,
+                        behavior: 'smooth'
+                    });
+                    setTimeout(() => { 
+                        this.isConfirmed = null
+                    }, 3000)   
                 },
                 cancelLog() {
                     this.submitInProgress = false
                     this.isConfirmed = false
-                    var cancelBanner = document.getElementById('scrollBanners');
-                    cancelBanner.scrollIntoView(false);
+                    scrollTo({
+                        top: 230,
+                        behavior: 'smooth'
+                    });
                     setTimeout(() => { 
                         this.isConfirmed = null
                     }, 3000)

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
@@ -1,6 +1,6 @@
 <body>
     <div id='seedingInput'>
-        <div class="alert-boxs" style='max-width: 500px; text-align: center; margin:auto; font-size: large'>
+        <div id="scrollBanners" class="alert-boxs" style='max-width: 500px; text-align: center; margin:auto; font-size: large'>
             <div data-cy='alert-success' class="alert alert-success" role="alert" v-show="isConfirmed == true">
                 Log created and saved successfully.
             </div>
@@ -204,6 +204,8 @@
                     })
                     this.isConfirmed = true
                     this.submitInProgress = false
+                    var confirmBanner = document.getElementById('scrollBanners');
+                    confirmBanner.scrollIntoView(false);
                     setTimeout(() => {
                         this.isConfirmed = null 
                     }, 3000)    
@@ -211,6 +213,8 @@
                 cancelLog() {
                     this.submitInProgress = false
                     this.isConfirmed = false
+                    var cancelBanner = document.getElementById('scrollBanners');
+                    cancelBanner.scrollIntoView(false);
                     setTimeout(() => { 
                         this.isConfirmed = null
                     }, 3000)

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.html
@@ -1,11 +1,11 @@
 <body>
     <div id='seedingInput'>
-        <div id="scrollBanners" class="alert-boxs" style='max-width: 500px; text-align: center; margin:auto; font-size: large'>
+        <div data-cy="alert-container" id="scrollBanners" class="alert-boxs" style='max-width: 500px; text-align: center; margin:auto; font-size: large'>
+            <div data-cy='alert-cancel' class="alert alert-danger" style="display: none;" role="alert" v-show="isConfirmed == false">
+                Log submission canceled by user. The log is <strong>NOT</strong> saved.  
+            </div>
             <div data-cy='alert-success' class="alert alert-success" role="alert" v-show="isConfirmed == true">
                 Log created and saved successfully.
-            </div>
-            <div data-cy='alert-cancel'class="alert alert-danger" style="display: none;" role="alert" v-show="isConfirmed == false">
-                Log submission canceled by user. The log is <strong>NOT</strong> saved.  
             </div>
         </div>
         <h1 style='text-align:center;'>Seeding Input Log</h1> 

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.spec.js
@@ -797,14 +797,14 @@ describe('Test the seeding input page', () => {
                     })
             })
 
-            it.only('cancel test (alert message and maintain inputs)', () => {
+            it('cancel test (alert message and maintain inputs)', () => {
                 cy.get('[data-cy=submit-button]')
                     .click()
                 cy.get('[data-cy=cancel-button]')
                     .click()
                     .then(() => {
                         cy.get('[data-cy=alert-container]')
-                        cy.window().its('scrollY').should('equal', 139)
+                        cy.window().its('scrollY').should('equal', 300)
                     })
 
                 cy.get('[data-cy=alert-cancel')    
@@ -833,7 +833,7 @@ describe('Test the seeding input page', () => {
                     .should('not.be.disabled')
             })
 
-            it.only('confirm test (alert message and reset inputs)', () => {
+            it('confirm test (alert message and reset inputs)', () => {
                 cy.get('[data-cy=submit-button]')
                     .click()
                 cy.get('[data-cy=confirm-button]')
@@ -841,7 +841,7 @@ describe('Test the seeding input page', () => {
                     .then(() => {
                         cy.get('[data-cy=alert-container]')
                             .then(() => 
-                                cy.window().its('scrollY').should('equal', 139));
+                                cy.window().its('scrollY').should('equal', 300));
                     })
 
                 cy.get('[data-cy=alert-cancel')

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.spec.js
@@ -797,14 +797,14 @@ describe('Test the seeding input page', () => {
                     })
             })
 
-            it('cancel test (alert message and maintain inputs)', () => {
+            it.only('cancel test (alert message and maintain inputs)', () => {
                 cy.get('[data-cy=submit-button]')
                     .click()
                 cy.get('[data-cy=cancel-button]')
                     .click()
                     .then(() => {
                         cy.get('[data-cy=alert-container]')
-                        cy.window().its('scrollY').should('equal', 230)
+                        cy.window().its('scrollY').should('equal', 139)
                     })
 
                 cy.get('[data-cy=alert-cancel')    
@@ -833,7 +833,7 @@ describe('Test the seeding input page', () => {
                     .should('not.be.disabled')
             })
 
-            it('confirm test (alert message and reset inputs)', () => {
+            it.only('confirm test (alert message and reset inputs)', () => {
                 cy.get('[data-cy=submit-button]')
                     .click()
                 cy.get('[data-cy=confirm-button]')
@@ -841,7 +841,7 @@ describe('Test the seeding input page', () => {
                     .then(() => {
                         cy.get('[data-cy=alert-container]')
                             .then(() => 
-                                cy.window().its('scrollY').should('equal', 230));
+                                cy.window().its('scrollY').should('equal', 139));
                     })
 
                 cy.get('[data-cy=alert-cancel')

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.spec.js
@@ -543,7 +543,7 @@ describe('Test the seeding input page', () => {
         })
 
         context('Labor input test', () => {
-           
+
             beforeEach(() => {
                 cy.restoreLocalStorage()
             })
@@ -749,7 +749,6 @@ describe('Test the seeding input page', () => {
                 cy.get('[data-cy=num-seed-input] > [data-cy=text-input]')
                     .type('1')
                 cy.get('[data-cy=num-worker-input] > [data-cy=text-input]')
-                    .scrollIntoView()
                     .type('1')
                 cy.get('[data-cy=minute-input] > [data-cy=text-input]')
                     .type('1')
@@ -798,11 +797,17 @@ describe('Test the seeding input page', () => {
                     })
             })
 
-            it('cancel test (alert message and maintain inputs)', { scrollBehavior: false }, () => {
+            it.only('cancel test (alert message and maintain inputs)', () => {
                 cy.get('[data-cy=submit-button]')
                     .click()
                 cy.get('[data-cy=cancel-button]')
                     .click()
+                    .then(() => {
+                        cy.get('[data-cy=alert-success]')
+                            .then((element) => element[0].offsetTop)
+                            .then((offset) => cy.window().its('scrollY').should('equal', offset));
+                    })
+
                 cy.get('[data-cy=alert-cancel')    
                     .should('be.visible')
                     .wait(3000)
@@ -829,14 +834,20 @@ describe('Test the seeding input page', () => {
                     .should('not.be.disabled')
             })
 
-            it('confirm test (alert message and reset inputs)', { scrollBehavior: false }, () => {
+            it.only('confirm test (alert message and reset inputs)', () => {
                 cy.get('[data-cy=submit-button]')
                     .click()
                 cy.get('[data-cy=confirm-button]')
                     .click()
+                    .then(() => {
+                        cy.get('[data-cy=alert-cancel]')
+                            .then((element) => element[0].offsetTop)
+                            .then((offset) => cy.window().its('scrollY').should('equal', offset));
+                    })
+
                 cy.get('[data-cy=alert-cancel')
                     .should('not.be.visible')
-                cy.get('[data-cy=alert-success')    // need to add scroll up test here after added
+                cy.get('[data-cy=alert-success')   
                     .should('be.visible')
                     .wait(3000)
                     .should('not.be.visible')

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.spec.js
@@ -797,15 +797,14 @@ describe('Test the seeding input page', () => {
                     })
             })
 
-            it.only('cancel test (alert message and maintain inputs)', () => {
+            it('cancel test (alert message and maintain inputs)', () => {
                 cy.get('[data-cy=submit-button]')
                     .click()
                 cy.get('[data-cy=cancel-button]')
                     .click()
                     .then(() => {
-                        cy.get('[data-cy=alert-success]')
-                            .then((element) => element[0].offsetTop)
-                            .then((offset) => cy.window().its('scrollY').should('equal', offset));
+                        cy.get('[data-cy=alert-container]')
+                        cy.window().its('scrollY').should('equal', 230)
                     })
 
                 cy.get('[data-cy=alert-cancel')    
@@ -834,15 +833,15 @@ describe('Test the seeding input page', () => {
                     .should('not.be.disabled')
             })
 
-            it.only('confirm test (alert message and reset inputs)', () => {
+            it('confirm test (alert message and reset inputs)', () => {
                 cy.get('[data-cy=submit-button]')
                     .click()
                 cy.get('[data-cy=confirm-button]')
                     .click()
                     .then(() => {
-                        cy.get('[data-cy=alert-cancel]')
-                            .then((element) => element[0].offsetTop)
-                            .then((offset) => cy.window().its('scrollY').should('equal', offset));
+                        cy.get('[data-cy=alert-container]')
+                            .then(() => 
+                                cy.window().its('scrollY').should('equal', 230));
                     })
 
                 cy.get('[data-cy=alert-cancel')

--- a/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_field_kit/seedingInput.spec.js
@@ -749,6 +749,7 @@ describe('Test the seeding input page', () => {
                 cy.get('[data-cy=num-seed-input] > [data-cy=text-input]')
                     .type('1')
                 cy.get('[data-cy=num-worker-input] > [data-cy=text-input]')
+                    .scrollIntoView()
                     .type('1')
                 cy.get('[data-cy=minute-input] > [data-cy=text-input]')
                     .type('1')
@@ -797,12 +798,12 @@ describe('Test the seeding input page', () => {
                     })
             })
 
-            it('cancel test (alert message and maintain inputs)', () => {
+            it('cancel test (alert message and maintain inputs)', { scrollBehavior: false }, () => {
                 cy.get('[data-cy=submit-button]')
                     .click()
                 cy.get('[data-cy=cancel-button]')
                     .click()
-                cy.get('[data-cy=alert-cancel')     // need to add scroll up test here after added
+                cy.get('[data-cy=alert-cancel')    
                     .should('be.visible')
                     .wait(3000)
                     .should('not.be.visible')
@@ -828,7 +829,7 @@ describe('Test the seeding input page', () => {
                     .should('not.be.disabled')
             })
 
-            it('confirm test (alert message and reset inputs)', () => {
+            it('confirm test (alert message and reset inputs)', { scrollBehavior: false }, () => {
                 cy.get('[data-cy=submit-button]')
                     .click()
                 cy.get('[data-cy=confirm-button]')


### PR DESCRIPTION
__Pull Request Description__

Solves #510.  Added some simple JavaScript that scrolls to the top of the page once the user hits the confirm or cancel button. 

- [x] Add a test case for this functionality in the Seeding Input's e2e page

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
