### PR TITLE
Issue520 Configuration Integration to Seeding Report

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -49,9 +49,9 @@
                         <div v-else>
                             <p style="margin-left: 5%;">Total Row Feet Planted: <b><span data-cy='direct-total-rowft'>{{ totalRowFeet }}</span></b></p>
                             <p style="margin-left: 5%;">Total Bed Feet Planted: <b><span data-cy='direct-total-bedft'>{{ totalBedFeet }}</span></b></p>
-                            <p style="margin-left: 5%;">Total Hours: <b><span data-cy='direct-total-hours'>{{ totalDirectSeedingHours }}</span></b></p>
-                            <p style="margin-left: 5%;">Average Row Feet/Hour: <b><span data-cy='direct-total-rowft-hour'>{{ totalRowFeetPerHour }}</span></b></p>
-                            <p style="margin-left: 5%;">Average Bed Feet/Hour: <b><span data-cy='direct-total-bedfr-hour'>{{ totalBedFeetPerHour }}</span></b></p>
+                            <p style="margin-left: 5%;" v-show="configToIDMap.labor != 'Hidden'">Total Hours: <b><span data-cy='direct-total-hours'>{{ totalDirectSeedingHours }}</span></b></p>
+                            <p style="margin-left: 5%;" v-show="configToIDMap.labor != 'Hidden'">Average Row Feet/Hour: <b><span data-cy='direct-total-rowft-hour'>{{ totalRowFeetPerHour }}</span></b></p>
+                            <p style="margin-left: 5%;" v-show="configToIDMap.labor != 'Hidden'">Average Bed Feet/Hour: <b><span data-cy='direct-total-bedfr-hour'>{{ totalBedFeetPerHour }}</span></b></p>
                         </div>
                     </fieldset>
                     <fieldset data-cy="tray-summary" class="center-block panel panel-default" style="width: 47%;" v-if="!(selectedSeeding=='Direct Seedings')">
@@ -62,8 +62,8 @@
                         <div v-else>
                             <p style="margin-left: 5%;">Total Number of Seeds Planted: <b><span data-cy='tray-total-seeds'>{{ traySeedsPlanted }}</span></b></p>
                             <p style="margin-left: 5%;">Total Number of Trays: <b><span data-cy='tray-total-trays'>{{ totalNumTrays }}</span></b></p>
-                            <p style="margin-left: 5%;">Total Hours: <b><span data-cy='tray-total-seeds-hour'>{{ totalTraySeedingHours }}</span></b></p>
-                            <p style="margin-left: 5%;">Average Seeds Planted/Hour: <b><span data-cy='tray-avg-seeds-hour'>{{ aveSeedsPerHour }}</span></b></p>
+                            <p style="margin-left: 5%;" v-show="configToIDMap.labor != 'Hidden'">Total Hours: <b><span data-cy='tray-total-seeds-hour'>{{ totalTraySeedingHours }}</span></b></p>
+                            <p style="margin-left: 5%;" v-show="configToIDMap.labor != 'Hidden'">Average Seeds Planted/Hour: <b><span data-cy='tray-avg-seeds-hour'>{{ aveSeedsPerHour }}</span></b></p>
                         </div>
                     </fieldset>
                 </div>
@@ -113,6 +113,7 @@
                 userToIDMap: new Map(),
                 areaToIDMap: new Map(),
                 unitToIDMap: new Map(),
+                configToIDMap: new Map(),
 
                 rowBeingEdited: false,
                 errBanner: null,
@@ -168,7 +169,11 @@
                         this.visibleColumns = [true, true, true, true, true, true, true, false, false, false, true, true, true, true, true]
                     }
                     else if(selectedSeeding == 'Tray Seedings'){
-                        this.visibleColumns = [true, true, true, true,false, false, false, true, true, true,  true, true, true, true, true]
+                        this.visibleColumns = [true, true, true, true, false, false, false, true, true, true,  true, true, true, true, true]
+                    }
+                    if(this.configToIDMap.labor == 'Hidden') {
+                        this.visibleColumns[10] = false
+                        this.visibleColumns[11] = false
                     }
                 },
                 /**
@@ -769,6 +774,25 @@
                 getUnitToIDMap()
                     .then((response) => {
                         this.unitToIDMap = new Map(response)
+                    })
+                    .catch((err) => { 
+                        this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
+                        scrollBy({
+                            top: alertBounds.top - headerBounds.bottom,
+                            behavior: 'smooth'
+                        })
+                    })
+                getConfiguration()
+                    .then((response) => {
+                        this.configToIDMap = response.data
+                        if(this.configToIDMap.labor == "hidden") {
+                            this.visibleColumns[10] = false
+                            this.visibleColumns[11] = false
+                        }
                     })
                     .catch((err) => { 
                         this.errBanner = true


### PR DESCRIPTION
__Pull Request Description__

Fixes #520 . Added configuration feature to the seeding Report. Hides hour, worker column if the labor config is set to hidden. The summary table also hides average hour and total hour if the labor config is set to hidden. 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
