### PR TITLE
Removing Lingering Only Inside Seeding Report Test

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.spec.js
@@ -1317,7 +1317,7 @@ describe('Testing for the seeding report page', () => {
         // })
     })
 
-    context.only('Configuration tests', () => {
+    context('Configuration tests', () => {
         before(() =>{
             cy.login('manager1', 'farmdata2')
             .then(() => {


### PR DESCRIPTION
__Pull Request Description__

Just a quick PR to remove this only inside the Cypress test. 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
