### PR TITLE
Addition of a Transplanting Report

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/fd2_barn_kit.module
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/fd2_barn_kit.module
@@ -65,6 +65,15 @@ function fd2_barn_kit_menu() {
     'weight' => -10,
   );
 
+    $items['farm/fd2-barn-kit/transplantingReport'] = array(
+    'title' => 'Transplanting Report',
+    'type' => MENU_LOCAL_TASK,
+    'page callback' => 'fd2_barn_kit_view',
+    'page arguments' => array('transplantingReport.html'),
+    'access arguments' => array('view fd2 barn kit'),
+    'weight' => -10,
+  );
+
   return $items;
 };
 

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
@@ -1,0 +1,783 @@
+<body>
+    <div id="seedingReport" v-cloak>
+        <h1 class="text-center">Seeding Report</h1>
+        <div data-cy="alert-container" id="scrollBanners" class="alert-boxs" style='max-width: 500px; text-align: center; margin:auto; font-size: large'>
+            <div data-cy='alert-err-handler' class="alert alert-danger" style="display: none;" role="alert" v-show="errBanner == true" @click="hideBanner">
+                Error Processing Request. This may be an intermittent network issue. Please try again later. 
+            </div>
+        </div>
+        <fieldset :disabled="rowBeingEdited" class="panel panel-default center-block" style="width: 50%;">
+            <legend class="panel-heading" style="background-color: #d62a17; color: white;">Set Dates</legend>
+            <div style="display: flex;width: 100%; padding: 7px">
+                <date-range-selection data-cy="date-range-selection" class="center-block" @start-date-changed='startDateChange' @end-date-changed='endDateChange' 
+                @click='hide'
+                :set-start-date='startDate' :set-end-date='endDate'></date-range-selection>
+
+                <button data-cy="generate-rpt-btn" class="btn center-block btn-primary" v-if='!reportVisible' @click='seedingLogRequestWithDates'>Generate Report</button>
+            </div>
+        </fieldset>
+
+        <div v-if='reportVisible'>
+
+            <div v-if="transplantingLogs.length != 0">
+                <fieldset :disabled="rowBeingEdited" data-cy="filters-panel" class="center-block panel panel-default" style="width: 75%;">
+                    <legend class="panel-heading" style="background-color: #d62a17; color: white;">Filters</legend>
+                    <div style="display: flex; width: 100%;">                    
+                        <dropdown-with-all data-cy="crop-dropdown" class="center-block" :dropdown-list='cropList' includes-all selected-val='All' @selection-changed='cropChange'>Crop:</dropdown-with-all>
+
+                        <dropdown-with-all data-cy="area-dropdown" class="center-block" :dropdown-list='areaList' includes-all selected-val='All' @selection-changed='areaChange'>Area:</dropdown-with-all> 
+                    </div>
+                </fieldset>
+
+                <custom-table data-cy="report-table" :visible-columns='visibleColumns' :rows='tableRows' :headers='headers' :input-options='columnInputs' csv-name="transplantingReport_" @row-deleted="deleteRowLog" @row-edited='updateRow' @edit-clicked='disableFilters' @row-canceled='enableFilters' can-edit can-delete></custom-table>
+
+                <br>
+            </div>
+
+            <div data-cy="loader" class="loader center-block" v-if="stillLoading"></div>
+
+            <div v-if="!stillLoading && transplantingLogs.length != 0">
+                <br>
+                <div style="display: flex; width: 100%;">
+                    <fieldset data-cy="direct-summary" class="center-block panel panel-default" style="width: 50%;">
+                        <legend class="panel-heading" style="background-color: #d62a17; color: white;">Transplanting Summary</legend>
+                        <div>
+                            <p style="margin-left: 5%;">Total Row Feet Planted: <b><span data-cy='direct-total-rowft'>{{ totalRowFeet }}</span></b></p>
+                            <p style="margin-left: 5%;">Total Bed Feet Planted: <b><span data-cy='direct-total-bedft'>{{ totalBedFeet }}</span></b></p>
+                            <p style="margin-left: 5%;" v-show="configToIDMap.labor != 'Hidden'">Total Hours: <b><span data-cy='direct-total-hours'>{{ totalDirectSeedingHours }}</span></b></p>
+                            <p style="margin-left: 5%;" v-show="configToIDMap.labor != 'Hidden'">Average Row Feet/Hour: <b><span data-cy='direct-total-rowft-hour'>{{ totalRowFeetPerHour }}</span></b></p>
+                            <p style="margin-left: 5%;" v-show="configToIDMap.labor != 'Hidden'">Average Bed Feet/Hour: <b><span data-cy='direct-total-bedfr-hour'>{{ totalBedFeetPerHour }}</span></b></p>
+                        </div>
+                    </fieldset>
+                </div>
+            </div>
+            <div v-if="!stillLoading && transplantingLogs.length == 0">
+                <div class="box" data-cy="no-logs-message" style="  
+                    border: 5px solid #d62a17;
+                    background-color: white;
+                    padding: 20px;
+                    margin: auto;
+                    width: 50%;
+                    text-align: center;
+                    font-size: large;">
+                    No Logs Found in These Dates 
+                </div> 
+            </div>
+        </div>
+    </div>
+    <script>
+        var seedingReport = new Vue ({
+            el: '#seedingReport',
+            components: {
+                'custom-table': CustomTableComponent,
+                'date-range-selection': DateRangeSelectionComponent,
+                'dropdown-with-all': DropdownWithAllComponent
+            },
+            data: {
+                startDate:'2020-05-01',//dayjs().startOf('year').format('YYYY-MM-DD').toString(),
+                endDate: dayjs().format('YYYY-MM-DD').toString(),
+
+                stillLoading: true,
+                reportVisible: false,
+                transplantingLogs: [],
+                updateLog: [],
+
+                sessionToken: null,
+                selectedCrop: 'All',
+                selectedArea: 'All',
+                selectedSeeding: 'All',
+
+                headers: ['Date', 'Crop', 'Area', 'Transplanting Date', 'Bed Feet', 'Rows/Bed', 'Trays', 'Workers', 'Hours','Comments','User'],
+                visibleColumns: [true, true, true, true, true, true, true, true, true, true, true],
+
+                idToCropMap: new Map(),
+                cropToIDMap: new Map(),
+                idToUserMap: new Map(),
+                userToIDMap: new Map(),
+                areaToIDMap: new Map(),
+                unitToIDMap: new Map(),
+                configToIDMap: new Map(),
+
+                rowBeingEdited: false,
+                errBanner: null,
+            },
+            methods: {
+                hide(){
+                    this.reportVisible = false
+                    this.transplantingLogs = []
+                },
+                startDateChange(selectedDate){
+                    this.startDate = selectedDate
+                    //this.reportVisible = false
+                    //this.transplantingLogs = []
+                },
+                endDateChange(selectedDate){
+                    this.endDate = selectedDate
+                    //this.reportVisible = false
+                    //this.transplantingLogs = []
+                },
+                seedingLogRequestWithDates(){
+                    this.reportVisible = true
+                    let link = '/log.json?type=farm_transplanting&timestamp[ge]=' + dayjs(this.startDate).unix() + '&timestamp[le]=' + dayjs(this.endDate).unix()
+
+                    getAllPages(link, this.transplantingLogs)
+                        .then(() => {
+                            this.stillLoading = false
+                        })
+                        .catch((err) => { 
+                            this.errBanner = true
+                            var errorBanner = document.getElementById('scrollBanners')
+                            var pageHeader = document.getElementById('navbar')
+                            var headerBounds = pageHeader.getBoundingClientRect()
+                            var alertBounds = errorBanner.getBoundingClientRect()
+                            scrollBy({
+                                top: alertBounds.top - headerBounds.bottom,
+                                behavior: 'smooth'
+                            })
+                        })
+                    this.stillLoading = true
+                },
+                cropChange(selectedCrop){
+                    this.selectedCrop = selectedCrop
+                },
+                areaChange(selectedArea){
+                    this.selectedArea = selectedArea
+                },
+                seedingChange(selectedSeeding){
+                    this.selectedSeeding = selectedSeeding
+                    if(selectedSeeding == 'All'){
+                        this.visibleColumns = [true, true, true, true, true, true, true, true, true, true, true]
+                    }
+                    else if(selectedSeeding == 'Direct Seedings'){
+                        this.visibleColumns = [true, true, true, true, true, true, true, false, false, false, true, true, true, true, true]
+                    }
+                    else if(selectedSeeding == 'Tray Seedings'){
+                        this.visibleColumns = [true, true, true, true, false, false, false, true, true, true,  true, true, true, true, true]
+                    }
+                    if(this.configToIDMap.labor == 'Hidden') {
+                        this.visibleColumns[10] = false
+                        this.visibleColumns[11] = false
+                    }
+                },
+                /**
+                 * updates the log that the user saved
+                 */
+                updateRow(updateObject, id){
+                    this.updateLog = this.transplantingLogs.filter((x) => x.id === id)
+                    let updateSeedingObject = {}
+                    let updatePlantObject = {}
+                    
+                    /**
+                     * The Table component returns an object with the cells that were updated. We don't know how many or wich ones where updated, so we check for all possible cells that could have been updated.
+                     */
+                    let keys = Object.keys(updateObject)
+                    if(keys.includes('Hours') || keys.includes('Num Workers') || 
+                        keys.includes('Row/Bed') || keys.includes('Row Feet') ||
+                        keys.includes('Tray Seeds') || keys.includes('# of Trays') ||
+                        keys.includes('Cells Per Tray')){
+                        if(this.updateLog[0].log_category[0].name == 'Direct Seedings'){
+                            updateSeedingObject['quantity'] = this.quantityDirectSeeding
+                        }
+                        else{
+                            updateSeedingObject['quantity'] = this.quantityTraySeeding
+                        }
+                    }
+                    
+                    for(i=0; i < keys.length; i++){
+                        if(keys[i] == 'date'){
+                            updateSeedingObject['timestamp'] = dayjs(updateObject['date'], 'YYYY-MM-DD').unix()
+                        }
+                        else if(keys[i] == 'crop'){
+                            updateSeedingObject['data'] = {"crop_tid": this.cropToIDMap.get(updateObject['crop'])}
+                            updatePlantObject['crop'] = [{
+                                "id": this.cropToIDMap.get(updateObject['crop']),
+                                "resource": "taxonomy_term"
+                            }]
+                        }
+                        else if (keys[i] == 'area'){
+                            updateSeedingObject['movement'] = { 'area': [{
+                                "id": this.areaToIDMap.get(updateObject['area']),
+                                "resource": "taxonomy_term",}]
+                            }
+                        }
+                        else if(keys[i] == 'Hours'){
+                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Labor')].value = updateObject['Hours']
+
+                            this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Labor')].value = updateObject['Hours']
+                        }
+                        else if(keys[i] == 'Num Workers'){
+                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Workers')].value = updateObject['Num Workers']
+
+                            this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Workers')].value = updateObject['Num Workers']
+                        }
+                        else if(keys[i] == 'Comments'){
+                            updateSeedingObject['notes'] = {'value': updateObject['Comments'],
+                                'format': 'farm_format'}
+                        }
+                        else if(keys[i] == 'User'){
+                            updateSeedingObject['uid'] = {
+                                'id': this.userToIDMap.get(updateObject['User']),
+                                'resource': 'user'
+                            }
+                            updatePlantObject['uid'] = {
+                                'id': this.userToIDMap.get(updateObject['User']),
+                                'resource': 'user'
+                            }
+                        }
+                        else if(keys[i] == 'Row/Bed'){
+                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Rows/Bed')].value = updateObject['Row/Bed']
+
+                            this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Rows/Bed')].value = updateObject['Row/Bed']
+                        }
+                        else if(keys[i] == 'Row Feet'){
+                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Amount planted')].value = updateObject['Row Feet']
+
+                            this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Amount planted')].value = updateObject['Row Feet']
+                        }
+                        else if(keys[i] == 'Tray Seeds'){
+                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Seeds planted')].value = updateObject['Tray Seeds']
+
+                            this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Seeds planted')].value = updateObject['Tray Seeds']
+                        }
+                        else if(keys[i] == '# of Trays'){
+                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Flats used')].value = updateObject['# of Trays']
+
+                            this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Flats used')].value = updateObject['# of Trays']
+                        }
+                        else if(keys[i] == 'Cells Per Tray'){
+                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Cells/Flat')].value = updateObject['Cells Per Tray']
+
+                            this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Cells/Flat')].value = updateObject['Cells Per Tray']
+                        }   
+                    }
+                    //replace old update log with current update log
+                    if(keys.includes('Hours') || keys.includes('Num Workers') || 
+                        keys.includes('Row/Bed') || keys.includes('Row Feet') ||
+                        keys.includes('Tray Seeds') || keys.includes('# of Trays') ||
+                        keys.includes('Cells Per Tray')){
+                        for(var i=0; i < this.transplantingLogs.length; i++){
+                            if(this.transplantingLogs[i].id === id){
+                                this.transplantingLogs.splice(i, this.updateLog)
+                            }
+                        }    
+                    }
+                    
+                    let seedingUrl = '/log/' + id
+                    let plantingUrl = '/farm_asset/' + this.updateLog[0].asset[0].id
+                    //call updateRecord function to update planting log
+                    if(!(Object.entries(updatePlantObject).length === 0)){
+                        updateRecord(plantingUrl, updatePlantObject, this.sessionToken)
+                    }
+                    //call updateRecord function to update seeding log
+                    if(!(Object.entries(updateSeedingObject).length === 0)){
+                        updateRecord(seedingUrl, updateSeedingObject,this.sessionToken)
+                    }
+                    this.rowBeingEdited = false
+                },
+                /**
+                 * Uses deleteRecord function to delete the record in the database. Also deletes the record from the current logs that are in transplantingLogs
+                 */
+                deleteRowLog(logID) {
+                    let url = '/log/' + logID
+                    deleteRecord(url, this.sessionToken)
+                    for(var i=0; i < this.transplantingLogs.length; i++){
+                        if(this.transplantingLogs[i].id === logID){
+                            this.transplantingLogs.splice(i, 1)
+                        }
+                    }
+                },
+                disableFilters() {
+                    this.rowBeingEdited = true
+                },
+                enableFilters(){
+                    this.rowBeingEdited = false
+                },
+                hideBanner(){
+                    this.errBanner = false
+                },
+            },
+            computed: {
+                /**
+                 * tableRows() filters though transplantingLogs to get all the logs that have the correct crop, area, and/or type of seeding that has been selected by the user. Then takes the remaining logs and formats it so that the table component gets the necessary info
+                 */ 
+                tableRows() {
+                    let filterRows = this.transplantingLogs.filter((x) => x)
+
+                    if(this.selectedArea != 'All'){
+                        filterRows = filterRows.filter((x) => x.movement.area[0].name === this.selectedArea)
+                    }
+                    if(this.selectedCrop != 'All'){
+                        filterRows = filterRows.filter((x) => this.idToCropMap.get(x.data.crop_tid) === this.selectedCrop)
+                    }
+                    if(this.selectedSeeding != 'All'){
+                        filterRows = filterRows.filter((x) => x.log_category[0].name === this.selectedSeeding)
+                    }
+                    let $vm = this
+                    let rows = filterRows.map(function(h) {
+                        let rowBed = 0
+                        let rowFeet = 0
+                        let bedFeet = 0
+                        let traySeeds = 0
+                        let numOfTrays = 0
+                        let cellsPerTray = 0
+                        let hours = 0
+                        let numWorkers = 0
+
+                        hours = h.quantity[3].value
+                        numWorkers = h.quantity[4].value
+                        return{
+                            id: h.id,
+                            data: [
+                                dayjs.unix(h.timestamp).format('YYYY-MM-DD'),
+                                $vm.idToCropMap.get(h.data.crop_tid),
+                                h.movement.area[0].name, 
+                                h.log_category[0].name.substring(0, h.log_category[0].name.indexOf(' ')), 
+                                rowFeet = h.quantity[0].value,
+                                bedFeet,
+                                rowBed,
+                                numOfTrays = h.quantity[2].value,
+                                cellsPerTray,
+                                (Math.round(numWorkers*100))/100,
+                                ((Math.round(hours*100))/100).toFixed(2),
+                                h.lot_number,
+                                h.notes.value,
+                                $vm.idToUserMap.get(h.uid.id)
+                            ]
+                        }
+                    })
+                    rows.sort(function compareNumbers(a, b) {
+                        return new Date(a.data[0]).getTime() - new Date(b.data[0]).getTime();
+                    })   
+                    return rows
+                },
+                getTableOneType(){
+                    let currentType = this.tableRows[0].data[3]
+                    for (i = 0 ; i < this.tableRows.length ; i ++){
+                        if (this.tableRows[i].data[3] == currentType){
+                            currentType = this.tableRows[i].data[3]
+                        }else{
+                            return false
+                        }
+                    }
+                    return currentType
+                },
+                /**
+                 * returns a sorted array of all the crops in the current logs. If area or type of seeding does not equal 'All' then the array will only contain crops that have the selected area and/or type of seeding
+                 */ 
+                cropList(){
+                    let seedFilter = []
+                    if(this.selectedSeeding != 'All'){
+                        seedFilter = this.transplantingLogs.filter((x) => x.log_category[0].name === this.selectedSeeding)
+                    }
+                    else{
+                        seedFilter = this.transplantingLogs.filter((x) => x)
+                    }
+                    let cropArray = []
+                    if(this.selectedArea != 'All'){
+                        let areaFilter = seedFilter.filter((x) => x.movement.area[0].name === this.selectedArea)
+                        cropArray = areaFilter.map(h => 
+                            this.idToCropMap.get(h.data.crop_tid)
+                        )
+                    }
+                    else{
+                        cropArray = seedFilter.map(h=> 
+                            this.idToCropMap.get(h.data.crop_tid)
+                        )
+                    }
+
+                    let crops = new Set(cropArray)
+                    let newCropArray = Array.from(crops)
+                    return newCropArray.sort()
+                },
+                /**
+                 * returns a sorted array of all the areas in the current logs. If a crop or type of seeding does not equal 'All' then the array will only contain areas that have the selected crop and/or type of seeding
+                 */ 
+                areaList(){
+                    let seedFilter = []
+                    if(this.selectedSeeding != 'All'){
+                        seedFilter = this.transplantingLogs.filter((x) => x.log_category[0].name === this.selectedSeeding)
+                    }
+                    else{
+                        seedFilter = this.transplantingLogs.filter((x) => x)
+                    }
+                    let areaArray = []
+                    if(this.selectedCrop != 'All'){
+                        let cropFilter = seedFilter.filter((x) => this.idToCropMap.get(x.data.crop_tid) === this.selectedCrop)
+                        areaArray = cropFilter.map(h =>
+                            h.movement.area[0].name
+                        )
+                    }
+                    else{
+                        areaArray = seedFilter.map(h =>
+                            h.movement.area[0].name
+                        )
+                    }
+                    let areas = new Set(areaArray)
+                    let newAreaArray = Array.from(areas)
+                    return newAreaArray.sort()
+                },
+                /**
+                 * returns a sorted array of all the types of seeding in the current logs. If the area or crop does not equal 'All' then the array will only contain types of seeding that have the selected area and/or crop
+                 */ 
+                seedingTypeList(){
+                    let areaFilter = []
+                    if(this.selectedArea != 'All'){
+                        areaFilter = this.transplantingLogs.filter((x) => x.movement.area[0].name === this.selectedArea)
+                    }
+                    else{
+                        areaFilter = this.transplantingLogs.filter((x) => x)
+                    }
+                    let seedingTypeArray = []
+                    if(this.selectedCrop != 'All'){
+                        let cropFilter = areaFilter.filter((x) => this.idToCropMap.get(x.data.crop_tid) === this.selectedCrop)
+                        seedingTypeArray = cropFilter.map(h =>
+                            h.log_category[0].name
+                        )
+                    }
+                    else{
+                        seedingTypeArray = areaFilter.map(h => 
+                            h.log_category[0].name
+                        )
+                    }
+                    let seedingsType = new Set(seedingTypeArray)
+                    let newSeedingTypeArray = Array.from(seedingsType)
+                    return newSeedingTypeArray.sort()
+                },
+                /**
+                 * returns the total row feet for Direct Seeding
+                 */ 
+                totalRowFeet(){
+                    let tableData = this.tableRows
+                    let sumRowFeet = 0
+                    tableData.map(h => {
+                        sumRowFeet = sumRowFeet + parseInt(h.data[4])
+                    })
+                    return (Math.round(sumRowFeet*100))/100
+                },
+                /**
+                 * returns the total bed feet for Direct Seeding
+                 */ 
+                totalBedFeet(){
+                    let tableData = this.tableRows
+                    let sumBedFeet = 0
+                    tableData.map(h => {
+                        sumBedFeet = sumBedFeet + parseInt(h.data[5])
+                    })
+                    return sumBedFeet
+                },
+                /**
+                 * returns the total hours worked for direct seedings. Calculated by mulpitplying hours by workers for each log
+                 */ 
+                totalDirectSeedingHours(){
+                    let tableData = this.tableRows
+                    let filteredTableData = tableData.filter((x) => x.data[3] === 'Direct')
+                    let sumHours = 0
+                    filteredTableData.map(h => {
+                        sumHours = sumHours + h.data[10]//*h.data[11])
+                    })
+                    return (Math.round(sumHours*100))/100
+                },
+                /**
+                 * returns the bed feet per hour for the direct seedings. Calculated by dividing total bedfeet by total hours 
+                 */ 
+                totalBedFeetPerHour(){
+                    let bedFeet = this.totalBedFeet
+                    let hours = this.totalDirectSeedingHours
+                    return (Math.round((bedFeet/hours)*100))/100
+                },
+                /**
+                 * returns the row feet per hour for the direct seedings. Calculated by dividing total rowfeet by total hours
+                 */ 
+                totalRowFeetPerHour(){
+                    let rowFeet = this.totalRowFeet
+                    let hours = this.totalDirectSeedingHours
+                    return (Math.round((rowFeet/hours)*100))/100
+                },
+                /**
+                 * returns the total number of seeds planted for the tray seeding logs
+                 */ 
+                traySeedsPlanted(){
+                    let tableData = this.tableRows
+                    let totalTraySeeds = 0
+                    tableData.map(h =>
+                        totalTraySeeds = totalTraySeeds + parseFloat(h.data[7])
+                    )
+                    return totalTraySeeds
+                },
+                /**
+                 * returns the total number of trays(flats) for the Tray Seedings logs
+                 */ 
+                totalNumTrays(){
+                    let tableData = this.tableRows
+                    let totalTrays = 0
+                    tableData.map(h =>
+                        totalTrays = totalTrays + parseFloat(h.data[8])
+                    )
+                    return (Math.round(totalTrays*100))/100
+                },
+                /**
+                 * returns the total hours worked for the Tray Seeding logs. Calculated by multiplying the hours and workers for each log
+                 */ 
+                totalTraySeedingHours(){
+                    let tableData = this.tableRows
+                    let filteredTableData = tableData.filter((x) => x.data[3] === 'Tray')
+                    let sumHours = 0
+                    filteredTableData.map(h => {
+                        sumHours = sumHours + (parseFloat(h.data[10])*parseFloat(h.data[11]))
+                    })
+                    return (Math.round(sumHours*100))/100
+                },
+                /**
+                 * returns the average amount of seeds planted per hour. Calculated by having the total seedings planted divided by the total hours worked
+                 */ 
+                aveSeedsPerHour(){
+                    let seedsPlanted = this.traySeedsPlanted
+                    let hours = this.totalTraySeedingHours
+                    return (Math.round((seedsPlanted/hours)*100))/100
+                },
+                /**
+                 * returns the structure for updating the quantity section of the Direct Seeding Logs. The values have not been updated yet.
+                 */
+                quantityDirectSeeding(){
+                    return [
+                        {
+                            "measure": "length", 
+                            "value": this.updateLog[0].quantity[0].value,
+                            "unit": {
+                                "id": this.unitToIDMap.get('ROW FEET'), 
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Amount planted"
+                        },
+                        {
+                            "measure": "ratio", 
+                            "value": this.updateLog[0].quantity[1].value,
+                            "unit": {
+                                "id": this.unitToIDMap.get('ROWS/BED'),
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Rows/Bed"
+                        },
+                        {
+                            "measure": "time", 
+                            "value": this.updateLog[0].quantity[2].value,
+                            "unit": {
+                                "id": this.unitToIDMap.get('HOURS'),
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Labor"
+                        },
+                        {
+                            "measure": "count", 
+                            "value": this.updateLog[0].quantity[3].value,
+                            "unit": {
+                                "id": this.unitToIDMap.get('PEOPLE'),
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Workers"
+                        },
+                    ]
+                },
+                /**
+                 * returns the structure for updating the quantity section of the Tray Seeding Logs. The values have not been updated yet.
+                 */
+                quantityTraySeeding(){
+                    return [
+                        {
+                            "measure": "count", 
+                            "value": this.updateLog[0].quantity[0].value,
+                            "unit": {
+                                "id": this.unitToIDMap.get('SEEDS'), 
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Seeds planted"
+                        },
+                        {
+                            "measure": "count", 
+                            "value": this.updateLog[0].quantity[1].value,
+                            "unit": {
+                                "id": this.unitToIDMap.get('FLATS'), 
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Flats used" //also known as trays used
+                        },
+                        {
+                            "measure": "ratio", 
+                            "value": this.updateLog[0].quantity[2].value,
+                            "unit": {
+                                "id": this.unitToIDMap.get('CELLS/FLAT'),
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Cells/Flat"
+                        },
+                        {
+                            "measure": "time", 
+                            "value": this.updateLog[0].quantity[3].value,
+                            "unit": {
+                                "id": this.unitToIDMap.get('HOURS'),
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Labor"
+                        },
+                        {
+                            "measure": "count", 
+                            "value": this.updateLog[0].quantity[4].value,
+                            "unit": {
+                                "id": this.unitToIDMap.get('PEOPLE'),
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Workers"
+                        },
+                    ]
+                },
+                /**
+                 * returns the input options for each column in the table. Uses the maps in created to get the all crops, areas, and users in the database, in order to create respective dropdowns.
+                 */ 
+                columnInputs(){
+                    let userNameArray = []
+                    const userKeyIterator = this.userToIDMap.keys()
+                    for(i=0; i < this.userToIDMap.size; i++){
+                        userNameArray.push(userKeyIterator.next().value)
+                    }
+                    let cropNameArray = []
+                    for(let [key, info] of this.cropToIDMap){
+                        cropNameArray.push(key)
+                    }
+                    let areaNameArray = []
+                    const areaKeyIterator = this.areaToIDMap.keys()
+                    for(i=0; i < this.areaToIDMap.size; i++){
+                        areaNameArray.push(areaKeyIterator.next().value)
+                    }
+                    return [{type:'date'}, {type:'dropdown', value: cropNameArray}, {type:'dropdown', value: areaNameArray}, {type:'no input'}, {type:'number'}, {type:'number'}, {type:'no input'}, {type:'number'}, {type:'number'}, {type:'number'}, {type:'number'}, {type:'number'}, {type:'no input'}, {type:'text'}, {type:'dropdown', value: userNameArray}]
+                }
+            },
+            created() {
+                getSessionToken()
+                    .then((response) => {
+                        this.sessionToken = response
+                    })
+                    .catch((err) => { 
+                        this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
+                        scrollBy({
+                            top: alertBounds.top - headerBounds.bottom,
+                            behavior: 'smooth'
+                        })
+                    })
+                getIDToCropMap()
+                    .then((response) => {
+                        this.idToCropMap = new Map(response)
+                    })
+                    .catch((err) => { 
+                        this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
+                        scrollBy({
+                            top: alertBounds.top - headerBounds.bottom,
+                            behavior: 'smooth'
+                        })
+                    })
+                getCropToIDMap()
+                    .then((response) => {
+                        this.cropToIDMap = new Map(response)
+                    })
+                    .catch((err) => { 
+                        this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
+                        scrollBy({
+                            top: alertBounds.top - headerBounds.bottom,
+                            behavior: 'smooth'
+                        })
+                    })
+                getIDToUserMap()
+                    .then((response) => {
+                        this.idToUserMap = new Map (response)
+                    })
+                    .catch((err) => { 
+                        this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
+                        scrollBy({
+                            top: alertBounds.top - headerBounds.bottom,
+                            behavior: 'smooth'
+                        })
+                    })
+                getUserToIDMap()
+                    .then((response) => {
+                        this.userToIDMap = new Map (response)
+                    })
+                    .catch((err) => { 
+                        this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
+                        scrollBy({
+                            top: alertBounds.top - headerBounds.bottom,
+                            behavior: 'smooth'
+                        })
+                    })
+                getAreaToIDMap()
+                    .then((response) => {
+                        this.areaToIDMap = new Map(response)
+                    })
+                    .catch((err) => { 
+                        this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
+                        scrollBy({
+                            top: alertBounds.top - headerBounds.bottom,
+                            behavior: 'smooth'
+                        })
+                    })
+                getUnitToIDMap()
+                    .then((response) => {
+                        this.unitToIDMap = new Map(response)
+                    })
+                    .catch((err) => { 
+                        this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
+                        scrollBy({
+                            top: alertBounds.top - headerBounds.bottom,
+                            behavior: 'smooth'
+                        })
+                    })
+                getConfiguration()
+                    .then((response) => {
+                        this.configToIDMap = response.data
+                        if(this.configToIDMap.labor == "hidden") {
+                            this.visibleColumns[10] = false
+                            this.visibleColumns[11] = false
+                        }
+                    })
+                    .catch((err) => { 
+                        this.errBanner = true
+                        var errorBanner = document.getElementById('scrollBanners')
+                        var pageHeader = document.getElementById('navbar')
+                        var headerBounds = pageHeader.getBoundingClientRect()
+                        var alertBounds = errorBanner.getBoundingClientRect()
+                        scrollBy({
+                            top: alertBounds.top - headerBounds.bottom,
+                            behavior: 'smooth'
+                        })
+                    })
+            }
+        })
+        Vue.config.devtools = true;
+    </script>
+</body>

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
@@ -1,9 +1,9 @@
 <body>
     <div id="seedingReport" v-cloak>
-        <h1 class="text-center">Seeding Report</h1>
+        <h1 class="text-center">Transplanting Report</h1>
         <div data-cy="alert-container" id="scrollBanners" class="alert-boxs" style='max-width: 500px; text-align: center; margin:auto; font-size: large'>
             <div data-cy='alert-err-handler' class="alert alert-danger" style="display: none;" role="alert" v-show="errBanner == true" @click="hideBanner">
-                Error Processing Request. This may be an intermittent network issue. Please try again later. 
+                Error Processing Requt. This may be an intermittent network issue. Please try again later. 
             </div>
         </div>
         <fieldset :disabled="rowBeingEdited" class="panel panel-default center-block" style="width: 50%;">
@@ -39,7 +39,7 @@
             <div v-if="!stillLoading && transplantingLogs.length != 0">
                 <br>
                 <div style="display: flex; width: 100%;">
-                    <fieldset data-cy="direct-summary" class="center-block panel panel-default" style="width: 50%;">
+                    <fieldset data-cy="transplanting-summary" class="center-block panel panel-default" style="width: 50%;">
                         <legend class="panel-heading" style="background-color: #d62a17; color: white;">Transplanting Summary</legend>
                         <div>
                             <p style="margin-left: 5%;">Total Row Feet Planted: <b><span data-cy='transplant-total-rowft'>{{ totalRowFeet }}</span></b></p>
@@ -246,7 +246,7 @@
                     if(!(Object.entries(updatePlantObject).length === 0)){
                         updateRecord(plantingUrl, updatePlantObject, this.sessionToken)
                     }
-                    //call updateRecord function to update seeding log
+                    //call updateRecord function to update transplanting log
                     if(!(Object.entries(updateSeedingObject).length === 0)){
                         updateRecord(seedingUrl, updateSeedingObject,this.sessionToken)
                     }
@@ -325,7 +325,7 @@
                 },
 
                 /**
-                 * returns a sorted array of all the crops in the current logs. If area or type of seeding does not equal 'All' then the array will only contain crops that have the selected area and/or type of seeding
+                 * returns a sorted array of all the crops in the current logs. If area does not equal 'All' then the array will only contain crops that have the selected area 
                  */ 
                 cropList(){
                     let cropArray = []
@@ -346,7 +346,7 @@
                     return newCropArray.sort()
                 },
                 /**
-                 * returns a sorted array of all the areas in the current logs. If a crop or type of seeding does not equal 'All' then the array will only contain areas that have the selected crop and/or type of seeding
+                 * returns a sorted array of all the areas in the current logs. If a crop does not equal 'All' then the array will only contain areas that have the selected crop
                  */ 
                 areaList(){
                     let areaArray = []
@@ -383,7 +383,7 @@
                     let tableData = this.tableRows
                     let sumBedFeet = 0
                     tableData.map(h => {
-                        sumBedFeet = sumBedFeet + parseInt(h.data[5])
+                        sumBedFeet = sumBedFeet + parseInt(h.data[3])
                     })
                     return sumBedFeet
                 },
@@ -394,9 +394,10 @@
                     let tableData = this.tableRows
                     let sumHours = 0
                     tableData.map(h => {
-                        hours = parseFloat(h.data[9]);
+                        hours = parseFloat(h.data[7]);
                         sumHours = sumHours + hours
                     })
+                    // console.log(sumHours)
                     return (Math.round(sumHours*100))/100
                 },
                 /**
@@ -404,7 +405,7 @@
                  */ 
                 totalBedFeetPerHour(){
                     let bedFeet = this.totalBedFeet
-                    let hours = this.totalDirectSeedingHours
+                    let hours = this.totalHours
                     return (Math.round((bedFeet/hours)*100))/100
                 },
                 /**
@@ -412,19 +413,8 @@
                  */ 
                 totalRowFeetPerHour(){
                     let rowFeet = this.totalRowFeet
-                    let hours = this.totalDirectSeedingHours
+                    let hours = this.totalHours
                     return (Math.round((rowFeet/hours)*100))/100
-                },
-                /**
-                 * returns the total number of seeds planted for the tray seeding logs
-                 */ 
-                traySeedsPlanted(){
-                    let tableData = this.tableRows
-                    let totalTraySeeds = 0
-                    tableData.map(h =>
-                        totalTraySeeds = totalTraySeeds + parseFloat(h.data[7])
-                    )
-                    return totalTraySeeds
                 },
                 /**
                  * returns the total number of trays(flats) for the Tray Seedings logs
@@ -433,7 +423,7 @@
                     let tableData = this.tableRows
                     let totalTrays = 0
                     tableData.map(h =>
-                        totalTrays = totalTrays + parseFloat(h.data[8])
+                        totalTrays = totalTrays + parseFloat(h.data[6])
                     )
                     return (Math.round(totalTrays*100))/100
                 },

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
@@ -163,12 +163,7 @@
                     let keys = Object.keys(updateObject)
                     if(keys.includes('Hours') || keys.includes('Workers') || keys.includes('Bed Feet') || keys.includes('Row Feet') ||
                         keys.includes('Rows/Bed') ||   keys.includes('Trays')){
-                        if(this.updateLog[0].log_category[0].name == 'Direct Seedings'){
-                            updateSeedingObject['quantity'] = this.quantityDirectSeeding
-                        }
-                        else{
                             updateSeedingObject['quantity'] = this.quantityTransplantSeeding
-                        }
                     }
                     
                     for(i=0; i < keys.length; i++){
@@ -194,9 +189,9 @@
                             this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Labor')].value = updateObject['Hours']
                         }
                         else if(keys[i] == 'Workers'){
-                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Workers')].value = updateObject['Num Workers']
+                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Workers')].value = updateObject['Workers']
 
-                            this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Workers')].value = updateObject['Num Workers']
+                            this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Workers')].value = updateObject['Workers']
                         }
                         else if(keys[i] == 'Comments'){
                             updateSeedingObject['notes'] = {'value': updateObject['Comments'],
@@ -213,9 +208,9 @@
                             }
                         }
                         else if(keys[i] == 'Row/Bed'){
-                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Rows/Bed')].value = updateObject['Row/Bed']
+                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Rows/Bed')].value = updateObject['Rows/Bed']
 
-                            this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Rows/Bed')].value = updateObject['Row/Bed']
+                            this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Rows/Bed')].value = updateObject['Rows/Bed']
                         }
                         else if(keys[i] == 'Row Feet'){
                             updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Amount planted')].value = updateObject['Row Feet']
@@ -223,9 +218,9 @@
                             this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Amount planted')].value = updateObject['Row Feet']
                         }
                         else if(keys[i] == '# of Trays'){
-                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Flats used')].value = updateObject['# of Trays']
+                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Flats')].value = updateObject['Trays']
 
-                            this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Flats used')].value = updateObject['# of Trays']
+                            this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Flats')].value = updateObject['Trays']
                         } 
                     }
                     //replace old update log with current update log
@@ -240,7 +235,7 @@
                         }    
                     }
                     
-                    let seedingUrl = '/log/' + id
+                    let transplantUrl = '/log/' + id
                     let plantingUrl = '/farm_asset/' + this.updateLog[0].asset[0].id
                     //call updateRecord function to update planting log
                     if(!(Object.entries(updatePlantObject).length === 0)){
@@ -248,7 +243,7 @@
                     }
                     //call updateRecord function to update transplanting log
                     if(!(Object.entries(updateSeedingObject).length === 0)){
-                        updateRecord(seedingUrl, updateSeedingObject,this.sessionToken)
+                        updateRecord(transplantUrl, updateSeedingObject,this.sessionToken)
                     }
                     this.rowBeingEdited = false
                 },
@@ -406,6 +401,9 @@
                 totalBedFeetPerHour(){
                     let bedFeet = this.totalBedFeet
                     let hours = this.totalHours
+                    if (hours == 0) {
+                        return "N/A"
+                    }
                     return (Math.round((bedFeet/hours)*100))/100
                 },
                 /**
@@ -414,6 +412,9 @@
                 totalRowFeetPerHour(){
                     let rowFeet = this.totalRowFeet
                     let hours = this.totalHours
+                    if (hours == 0) {
+                        return "N/A"
+                    }
                     return (Math.round((rowFeet/hours)*100))/100
                 },
                 /**
@@ -432,6 +433,11 @@
                  * returns the structure for updating the quantity section of the Transplanting Seeding Logs. The values have not been updated yet.
                  */
                 quantityTransplantSeeding(){
+                    console.log("0: " + this.updateLog[0].quantity[0].value)
+                    console.log("1: " + this.updateLog[0].quantity[1].value)
+                    console.log("2: " + this.updateLog[0].quantity[2].value)
+                    console.log("3: " + this.updateLog[0].quantity[3].value)
+                    console.log("4: " + this.updateLog[0].quantity[4].value)
                     return [
                         {
                             "measure": "length", 
@@ -452,8 +458,17 @@
                             "label": "Rows/Bed"
                         },
                         {
-                            "measure": "time", 
+                            "measure": "count", 
                             "value": this.updateLog[0].quantity[2].value,
+                            "unit": {
+                                "id": this.unitToIDMap.get('FLATS'),
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Flats"
+                        },
+                        {
+                            "measure": "time", 
+                            "value": this.updateLog[0].quantity[3].value,
                             "unit": {
                                 "id": this.unitToIDMap.get('HOURS'),
                                 "resource": "taxonomy_term"
@@ -462,7 +477,7 @@
                         },
                         {
                             "measure": "count", 
-                            "value": this.updateLog[0].quantity[3].value,
+                            "value": this.updateLog[0].quantity[4].value,
                             "unit": {
                                 "id": this.unitToIDMap.get('PEOPLE'),
                                 "resource": "taxonomy_term"

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
@@ -145,8 +145,8 @@
                 },
                 configChange(){
                     if(this.configToIDMap.labor == 'Hidden') {
-                        this.visibleColumns[10] = false
-                        this.visibleColumns[11] = false
+                        this.visibleColumns[7] = false
+                        this.visibleColumns[8] = false
                     }
                 },
                 /**
@@ -601,9 +601,9 @@
                 getConfiguration()
                     .then((response) => {
                         this.configToIDMap = response.data
-                        if(this.configToIDMap.labor == "hidden") {
-                            this.visibleColumns[10] = false
-                            this.visibleColumns[11] = false
+                        if(this.configToIDMap.labor == "Hidden") {
+                            this.visibleColumns[7] = false
+                            this.visibleColumns[8] = false
                         }
                     })
                     .catch((err) => { 

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
@@ -87,8 +87,8 @@
                 selectedCrop: 'All',
                 selectedArea: 'All',
 
-                headers: ['Seeding Date', 'Crop', 'Area', 'Transplanting Date', 'Bed Feet', 'Row Feet', 'Rows/Bed', 'Trays', 'Workers', 'Hours','Comments','User'],
-                visibleColumns: [true, true, true, true, true, true, true, true, true, true, true, true],
+                headers: ['Date', 'Crop', 'Area', 'Bed Feet', 'Row Feet', 'Rows/Bed', 'Trays', 'Workers', 'Hours','Comments','User'],
+                visibleColumns: [true, true, true, true, true, true, true, true, true, true, true],
 
                 idToCropMap: new Map(),
                 cropToIDMap: new Map(),
@@ -161,30 +161,28 @@
                      * The Table component returns an object with the cells that were updated. We don't know how many or wich ones where updated, so we check for all possible cells that could have been updated.
                      */
                     let keys = Object.keys(updateObject)
-                    if(keys.includes('Hours') || keys.includes('Num Workers') || 
-                        keys.includes('Row/Bed') || keys.includes('Row Feet') ||
-                        keys.includes('Tray Seeds') || keys.includes('# of Trays') ||
-                        keys.includes('Cells Per Tray')){
+                    if(keys.includes('Hours') || keys.includes('Workers') || keys.includes('Bed Feet') || keys.includes('Row Feet') ||
+                        keys.includes('Rows/Bed') ||   keys.includes('Trays')){
                         if(this.updateLog[0].log_category[0].name == 'Direct Seedings'){
                             updateSeedingObject['quantity'] = this.quantityDirectSeeding
                         }
                         else{
-                            updateSeedingObject['quantity'] = this.quantityTraySeeding
+                            updateSeedingObject['quantity'] = this.quantityTransplantSeeding
                         }
                     }
                     
                     for(i=0; i < keys.length; i++){
-                        if(keys[i] == 'date'){
+                        if(keys[i] == 'Date'){
                             updateSeedingObject['timestamp'] = dayjs(updateObject['date'], 'YYYY-MM-DD').unix()
                         }
-                        else if(keys[i] == 'crop'){
+                        else if(keys[i] == 'Crop'){
                             updateSeedingObject['data'] = {"crop_tid": this.cropToIDMap.get(updateObject['crop'])}
                             updatePlantObject['crop'] = [{
                                 "id": this.cropToIDMap.get(updateObject['crop']),
                                 "resource": "taxonomy_term"
                             }]
                         }
-                        else if (keys[i] == 'area'){
+                        else if (keys[i] == 'Area'){
                             updateSeedingObject['movement'] = { 'area': [{
                                 "id": this.areaToIDMap.get(updateObject['area']),
                                 "resource": "taxonomy_term",}]
@@ -195,7 +193,7 @@
 
                             this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Labor')].value = updateObject['Hours']
                         }
-                        else if(keys[i] == 'Num Workers'){
+                        else if(keys[i] == 'Workers'){
                             updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Workers')].value = updateObject['Num Workers']
 
                             this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Workers')].value = updateObject['Num Workers']
@@ -224,21 +222,11 @@
 
                             this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Amount planted')].value = updateObject['Row Feet']
                         }
-                        else if(keys[i] == 'Tray Seeds'){
-                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Seeds planted')].value = updateObject['Tray Seeds']
-
-                            this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Seeds planted')].value = updateObject['Tray Seeds']
-                        }
                         else if(keys[i] == '# of Trays'){
                             updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Flats used')].value = updateObject['# of Trays']
 
                             this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Flats used')].value = updateObject['# of Trays']
-                        }
-                        else if(keys[i] == 'Cells Per Tray'){
-                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Cells/Flat')].value = updateObject['Cells Per Tray']
-
-                            this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Cells/Flat')].value = updateObject['Cells Per Tray']
-                        }   
+                        } 
                     }
                     //replace old update log with current update log
                     if(keys.includes('Hours') || keys.includes('Num Workers') || 
@@ -319,7 +307,6 @@
                                 dayjs.unix(h.timestamp).format('YYYY-MM-DD'),
                                 $vm.idToCropMap.get(h.data.crop_tid),
                                 h.movement.area[0].name, 
-                                (h.name).substring(0, 10),
                                 bedFeet,
                                 rowFeet,
                                 rowBed,
@@ -336,17 +323,7 @@
                     })   
                     return rows
                 },
-                // getTableOneType(){
-                //     let currentType = this.tableRows[0].data[3]
-                //     for (i = 0 ; i < this.tableRows.length ; i ++){
-                //         if (this.tableRows[i].data[3] == currentType){
-                //             currentType = this.tableRows[i].data[3]
-                //         }else{
-                //             return false
-                //         }
-                //     }
-                //     return currentType
-                // },
+
                 /**
                  * returns a sorted array of all the crops in the current logs. If area or type of seeding does not equal 'All' then the array will only contain crops that have the selected area and/or type of seeding
                  */ 
@@ -460,30 +437,11 @@
                     )
                     return (Math.round(totalTrays*100))/100
                 },
-                // /**
-                //  * returns the total hours worked for the Tray Seeding logs. Calculated by multiplying the hours and workers for each log
-                //  */ 
-                // totalTraySeedingHours(){
-                //     let tableData = this.tableRows
-                //     let filteredTableData = tableData.filter((x) => x.data[3] === 'Tray')
-                //     let sumHours = 0
-                //     filteredTableData.map(h => {
-                //         sumHours = sumHours + (parseFloat(h.data[10])*parseFloat(h.data[11]))
-                //     })
-                //     return (Math.round(sumHours*100))/100
-                // },
-                // /**
-                //  * returns the average amount of seeds planted per hour. Calculated by having the total seedings planted divided by the total hours worked
-                //  */ 
-                // aveSeedsPerHour(){
-                //     let seedsPlanted = this.traySeedsPlanted
-                //     let hours = this.totalTraySeedingHours
-                //     return (Math.round((seedsPlanted/hours)*100))/100
-                // },
+
                 /**
-                 * returns the structure for updating the quantity section of the Direct Seeding Logs. The values have not been updated yet.
+                 * returns the structure for updating the quantity section of the Transplanting Seeding Logs. The values have not been updated yet.
                  */
-                quantityDirectSeeding(){
+                quantityTransplantSeeding(){
                     return [
                         {
                             "measure": "length", 
@@ -524,58 +482,6 @@
                     ]
                 },
                 /**
-                 * returns the structure for updating the quantity section of the Tray Seeding Logs. The values have not been updated yet.
-                 */
-                quantityTraySeeding(){
-                    return [
-                        {
-                            "measure": "count", 
-                            "value": this.updateLog[0].quantity[0].value,
-                            "unit": {
-                                "id": this.unitToIDMap.get('SEEDS'), 
-                                "resource": "taxonomy_term"
-                            },
-                            "label": "Seeds planted"
-                        },
-                        {
-                            "measure": "count", 
-                            "value": this.updateLog[0].quantity[1].value,
-                            "unit": {
-                                "id": this.unitToIDMap.get('FLATS'), 
-                                "resource": "taxonomy_term"
-                            },
-                            "label": "Flats used" //also known as trays used
-                        },
-                        {
-                            "measure": "ratio", 
-                            "value": this.updateLog[0].quantity[2].value,
-                            "unit": {
-                                "id": this.unitToIDMap.get('CELLS/FLAT'),
-                                "resource": "taxonomy_term"
-                            },
-                            "label": "Cells/Flat"
-                        },
-                        {
-                            "measure": "time", 
-                            "value": this.updateLog[0].quantity[3].value,
-                            "unit": {
-                                "id": this.unitToIDMap.get('HOURS'),
-                                "resource": "taxonomy_term"
-                            },
-                            "label": "Labor"
-                        },
-                        {
-                            "measure": "count", 
-                            "value": this.updateLog[0].quantity[4].value,
-                            "unit": {
-                                "id": this.unitToIDMap.get('PEOPLE'),
-                                "resource": "taxonomy_term"
-                            },
-                            "label": "Workers"
-                        },
-                    ]
-                },
-                /**
                  * returns the input options for each column in the table. Uses the maps in created to get the all crops, areas, and users in the database, in order to create respective dropdowns.
                  */ 
                 columnInputs(){
@@ -593,7 +499,7 @@
                     for(i=0; i < this.areaToIDMap.size; i++){
                         areaNameArray.push(areaKeyIterator.next().value)
                     }
-                    return [{type:'date'}, {type:'dropdown', value: cropNameArray}, {type:'dropdown', value: areaNameArray}, {type:'no input'}, {type:'number'}, {type:'number'}, {type:'no input'}, {type:'number'}, {type:'number'}, {type:'number'}, {type:'number'}, {type:'number'}, {type:'no input'}, {type:'text'}, {type:'dropdown', value: userNameArray}]
+                    return [{type:'date'}, {type:'dropdown', value: cropNameArray}, {type:'dropdown', value: areaNameArray}, {type:'number'}, {type:'number'}, {type:'no input'}, {type:'number'}, {type:'number'}, {type:'number'}, {type:'text'}, {type:'dropdown', value: userNameArray}]
                 }
             },
             created() {

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
@@ -1,5 +1,5 @@
 <body>
-    <div id="seedingReport" v-cloak>
+    <div id="transplantingReport" v-cloak>
         <h1 class="text-center">Transplanting Report</h1>
         <div data-cy="alert-container" id="scrollBanners" class="alert-boxs" style='max-width: 500px; text-align: center; margin:auto; font-size: large'>
             <div data-cy='alert-err-handler' class="alert alert-danger" style="display: none;" role="alert" v-show="errBanner == true" @click="hideBanner">
@@ -67,8 +67,8 @@
         </div>
     </div>
     <script>
-        var seedingReport = new Vue ({
-            el: '#seedingReport',
+        var transplantingReport = new Vue ({
+            el: '#transplantingReport',
             components: {
                 'custom-table': CustomTableComponent,
                 'date-range-selection': DateRangeSelectionComponent,
@@ -143,18 +143,12 @@
                 areaChange(selectedArea){
                     this.selectedArea = selectedArea
                 },
-                configChange(){
-                    if(this.configToIDMap.labor == 'Hidden') {
-                        this.visibleColumns[7] = false
-                        this.visibleColumns[8] = false
-                    }
-                },
                 /**
                  * updates the log that the user saved
                  */
                 updateRow(updateObject, id){
                     this.updateLog = this.transplantingLogs.filter((x) => x.id === id)
-                    let updateSeedingObject = {}
+                    let updateTransplantingObject = {}
                     let updatePlantObject = {}
                     
                     /**
@@ -163,42 +157,42 @@
                     let keys = Object.keys(updateObject)
                     if(keys.includes('Hours') || keys.includes('Workers') || keys.includes('Bed Feet') || keys.includes('Row Feet') ||
                         keys.includes('Rows/Bed') ||   keys.includes('Trays')){
-                            updateSeedingObject['quantity'] = this.quantityTransplantSeeding
+                            updateTransplantingObject['quantity'] = this.quantityTransplantSeeding
                     }
                     
                     for(i=0; i < keys.length; i++){
                         if(keys[i] == 'date'){
-                            updateSeedingObject['timestamp'] = dayjs(updateObject['date'], 'YYYY-MM-DD').unix()
+                            updateTransplantingObject['timestamp'] = dayjs(updateObject['date'], 'YYYY-MM-DD').unix()
                         }
                         else if(keys[i] == 'crop'){
-                            updateSeedingObject['data'] = {"crop_tid": this.cropToIDMap.get(updateObject['crop'])}
+                            updateTransplantingObject['data'] = {"crop_tid": this.cropToIDMap.get(updateObject['crop'])}
                             updatePlantObject['crop'] = [{
                                 "id": this.cropToIDMap.get(updateObject['crop']),
                                 "resource": "taxonomy_term"
                             }]
                         }
                         else if (keys[i] == 'area'){
-                            updateSeedingObject['movement'] = { 'area': [{
+                            updateTransplantingObject['movement'] = { 'area': [{
                                 "id": this.areaToIDMap.get(updateObject['area']),
                                 "resource": "taxonomy_term",}]
                             }
                         }
                         else if(keys[i] == 'Hours'){
-                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Labor')].value = updateObject['Hours']
+                            updateTransplantingObject.quantity[quantityLocation(updateTransplantingObject.quantity, 'Labor')].value = updateObject['Hours']
 
                             this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Labor')].value = updateObject['Hours']
                         }
                         else if(keys[i] == 'Workers'){
-                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Workers')].value = updateObject['Workers']
+                            updateTransplantingObject.quantity[quantityLocation(updateTransplantingObject.quantity, 'Workers')].value = updateObject['Workers']
 
                             this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Workers')].value = updateObject['Workers']
                         }
                         else if(keys[i] == 'Comments'){
-                            updateSeedingObject['notes'] = {'value': updateObject['Comments'],
+                            updateTransplantingObject['notes'] = {'value': updateObject['Comments'],
                                 'format': 'farm_format'}
                         }
                         else if(keys[i] == 'User'){
-                            updateSeedingObject['uid'] = {
+                            updateTransplantingObject['uid'] = {
                                 'id': this.userToIDMap.get(updateObject['User']),
                                 'resource': 'user'
                             }
@@ -208,17 +202,17 @@
                             }
                         }
                         else if(keys[i] == 'Row/Bed'){
-                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Rows/Bed')].value = updateObject['Rows/Bed']
+                            updateTransplantingObject.quantity[quantityLocation(updateTransplantingObject.quantity, 'Rows/Bed')].value = updateObject['Rows/Bed']
 
                             this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Rows/Bed')].value = updateObject['Rows/Bed']
                         }
                         else if(keys[i] == 'Row Feet'){
-                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Amount planted')].value = updateObject['Row Feet']
+                            updateTransplantingObject.quantity[quantityLocation(updateTransplantingObject.quantity, 'Amount planted')].value = updateObject['Row Feet']
 
                             this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Amount planted')].value = updateObject['Row Feet']
                         }
                         else if(keys[i] == '# of Trays'){
-                            updateSeedingObject.quantity[quantityLocation(updateSeedingObject.quantity, 'Flats')].value = updateObject['Trays']
+                            updateTransplantingObject.quantity[quantityLocation(updateTransplantingObject.quantity, 'Flats')].value = updateObject['Trays']
 
                             this.updateLog[0].quantity[quantityLocation(this.updateLog[0].quantity, 'Flats')].value = updateObject['Trays']
                         } 
@@ -242,8 +236,8 @@
                         updateRecord(plantingUrl, updatePlantObject, this.sessionToken)
                     }
                     //call updateRecord function to update transplanting log
-                    if(!(Object.entries(updateSeedingObject).length === 0)){
-                        updateRecord(transplantUrl, updateSeedingObject,this.sessionToken)
+                    if(!(Object.entries(updateTransplantingObject).length === 0)){
+                        updateRecord(transplantUrl, updateTransplantingObject,this.sessionToken)
                     }
                     this.rowBeingEdited = false
                 },
@@ -390,7 +384,7 @@
                     let sumHours = 0
                     tableData.map(h => {
                         hours = parseFloat(h.data[7]);
-                        sumHours = sumHours + hours
+                        sumHours = sumHours + (h.data[7]*parseFloat(h.data[8]))
                     })
                     // console.log(sumHours)
                     return (Math.round(sumHours*100))/100
@@ -433,11 +427,6 @@
                  * returns the structure for updating the quantity section of the Transplanting Seeding Logs. The values have not been updated yet.
                  */
                 quantityTransplantSeeding(){
-                    console.log("0: " + this.updateLog[0].quantity[0].value)
-                    console.log("1: " + this.updateLog[0].quantity[1].value)
-                    console.log("2: " + this.updateLog[0].quantity[2].value)
-                    console.log("3: " + this.updateLog[0].quantity[3].value)
-                    console.log("4: " + this.updateLog[0].quantity[4].value)
                     return [
                         {
                             "measure": "length", 
@@ -505,7 +494,7 @@
                         areaNameArray.push(areaKeyIterator.next().value)
                     }
                     return [{type:'date'}, {type:'dropdown', value: cropNameArray}, {type:'dropdown', value: areaNameArray}, {type:'number'}, {type:'number'}, {type:'no input'}, {type:'number'}, {type:'number'}, {type:'number'}, {type:'text'}, {type:'dropdown', value: userNameArray}]
-                }
+                },
             },
             created() {
                 getSessionToken()

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
@@ -167,17 +167,17 @@
                     }
                     
                     for(i=0; i < keys.length; i++){
-                        if(keys[i] == 'Date'){
+                        if(keys[i] == 'date'){
                             updateSeedingObject['timestamp'] = dayjs(updateObject['date'], 'YYYY-MM-DD').unix()
                         }
-                        else if(keys[i] == 'Crop'){
+                        else if(keys[i] == 'crop'){
                             updateSeedingObject['data'] = {"crop_tid": this.cropToIDMap.get(updateObject['crop'])}
                             updatePlantObject['crop'] = [{
                                 "id": this.cropToIDMap.get(updateObject['crop']),
                                 "resource": "taxonomy_term"
                             }]
                         }
-                        else if (keys[i] == 'Area'){
+                        else if (keys[i] == 'area'){
                             updateSeedingObject['movement'] = { 'area': [{
                                 "id": this.areaToIDMap.get(updateObject['area']),
                                 "resource": "taxonomy_term",}]

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
@@ -42,11 +42,12 @@
                     <fieldset data-cy="direct-summary" class="center-block panel panel-default" style="width: 50%;">
                         <legend class="panel-heading" style="background-color: #d62a17; color: white;">Transplanting Summary</legend>
                         <div>
-                            <p style="margin-left: 5%;">Total Row Feet Planted: <b><span data-cy='direct-total-rowft'>{{ totalRowFeet }}</span></b></p>
-                            <p style="margin-left: 5%;">Total Bed Feet Planted: <b><span data-cy='direct-total-bedft'>{{ totalBedFeet }}</span></b></p>
-                            <p style="margin-left: 5%;" v-show="configToIDMap.labor != 'Hidden'">Total Hours: <b><span data-cy='direct-total-hours'>{{ totalDirectSeedingHours }}</span></b></p>
-                            <p style="margin-left: 5%;" v-show="configToIDMap.labor != 'Hidden'">Average Row Feet/Hour: <b><span data-cy='direct-total-rowft-hour'>{{ totalRowFeetPerHour }}</span></b></p>
-                            <p style="margin-left: 5%;" v-show="configToIDMap.labor != 'Hidden'">Average Bed Feet/Hour: <b><span data-cy='direct-total-bedfr-hour'>{{ totalBedFeetPerHour }}</span></b></p>
+                            <p style="margin-left: 5%;">Total Row Feet Planted: <b><span data-cy='transplant-total-rowft'>{{ totalRowFeet }}</span></b></p>
+                            <p style="margin-left: 5%;">Total Bed Feet Planted: <b><span data-cy='transplant-total-bedft'>{{ totalBedFeet }}</span></b></p>
+                            <p style="margin-left: 5%;">Total Number of Trays: <b><span data-cy='transplant-total-numTrays'>{{ totalNumTrays }}</span></b></p>
+                            <p style="margin-left: 5%;" v-show="configToIDMap.labor != 'Hidden'">Total Hours: <b><span data-cy='transplant-total-hours'>{{ totalHours }}</span></b></p>
+                            <p style="margin-left: 5%;" v-show="configToIDMap.labor != 'Hidden'">Average Row Feet/Hour: <b><span data-cy='transplant-total-rowft-hour'>{{ totalRowFeetPerHour }}</span></b></p>
+                            <p style="margin-left: 5%;" v-show="configToIDMap.labor != 'Hidden'">Average Bed Feet/Hour: <b><span data-cy='transplant-total-bedfr-hour'>{{ totalBedFeetPerHour }}</span></b></p>
                         </div>
                     </fieldset>
                 </div>
@@ -85,10 +86,9 @@
                 sessionToken: null,
                 selectedCrop: 'All',
                 selectedArea: 'All',
-                selectedSeeding: 'All',
 
-                headers: ['Date', 'Crop', 'Area', 'Transplanting Date', 'Bed Feet', 'Rows/Bed', 'Trays', 'Workers', 'Hours','Comments','User'],
-                visibleColumns: [true, true, true, true, true, true, true, true, true, true, true],
+                headers: ['Seeding Date', 'Crop', 'Area', 'Transplanting Date', 'Bed Feet', 'Row Feet', 'Rows/Bed', 'Trays', 'Workers', 'Hours','Comments','User'],
+                visibleColumns: [true, true, true, true, true, true, true, true, true, true, true, true],
 
                 idToCropMap: new Map(),
                 cropToIDMap: new Map(),
@@ -143,17 +143,7 @@
                 areaChange(selectedArea){
                     this.selectedArea = selectedArea
                 },
-                seedingChange(selectedSeeding){
-                    this.selectedSeeding = selectedSeeding
-                    if(selectedSeeding == 'All'){
-                        this.visibleColumns = [true, true, true, true, true, true, true, true, true, true, true]
-                    }
-                    else if(selectedSeeding == 'Direct Seedings'){
-                        this.visibleColumns = [true, true, true, true, true, true, true, false, false, false, true, true, true, true, true]
-                    }
-                    else if(selectedSeeding == 'Tray Seedings'){
-                        this.visibleColumns = [true, true, true, true, false, false, false, true, true, true,  true, true, true, true, true]
-                    }
+                configChange(){
                     if(this.configToIDMap.labor == 'Hidden') {
                         this.visibleColumns[10] = false
                         this.visibleColumns[11] = false
@@ -309,20 +299,18 @@
                     if(this.selectedCrop != 'All'){
                         filterRows = filterRows.filter((x) => this.idToCropMap.get(x.data.crop_tid) === this.selectedCrop)
                     }
-                    if(this.selectedSeeding != 'All'){
-                        filterRows = filterRows.filter((x) => x.log_category[0].name === this.selectedSeeding)
-                    }
                     let $vm = this
                     let rows = filterRows.map(function(h) {
                         let rowBed = 0
                         let rowFeet = 0
                         let bedFeet = 0
-                        let traySeeds = 0
                         let numOfTrays = 0
-                        let cellsPerTray = 0
                         let hours = 0
                         let numWorkers = 0
 
+                        rowFeet = h.quantity[0].value
+                        rowBed = h.quantity[1].value
+                        bedFeet = rowFeet/rowBed
                         hours = h.quantity[3].value
                         numWorkers = h.quantity[4].value
                         return{
@@ -331,15 +319,13 @@
                                 dayjs.unix(h.timestamp).format('YYYY-MM-DD'),
                                 $vm.idToCropMap.get(h.data.crop_tid),
                                 h.movement.area[0].name, 
-                                h.log_category[0].name.substring(0, h.log_category[0].name.indexOf(' ')), 
-                                rowFeet = h.quantity[0].value,
+                                (h.name).substring(0, 10),
                                 bedFeet,
+                                rowFeet,
                                 rowBed,
                                 numOfTrays = h.quantity[2].value,
-                                cellsPerTray,
                                 (Math.round(numWorkers*100))/100,
                                 ((Math.round(hours*100))/100).toFixed(2),
-                                h.lot_number,
                                 h.notes.value,
                                 $vm.idToUserMap.get(h.uid.id)
                             ]
@@ -350,37 +336,30 @@
                     })   
                     return rows
                 },
-                getTableOneType(){
-                    let currentType = this.tableRows[0].data[3]
-                    for (i = 0 ; i < this.tableRows.length ; i ++){
-                        if (this.tableRows[i].data[3] == currentType){
-                            currentType = this.tableRows[i].data[3]
-                        }else{
-                            return false
-                        }
-                    }
-                    return currentType
-                },
+                // getTableOneType(){
+                //     let currentType = this.tableRows[0].data[3]
+                //     for (i = 0 ; i < this.tableRows.length ; i ++){
+                //         if (this.tableRows[i].data[3] == currentType){
+                //             currentType = this.tableRows[i].data[3]
+                //         }else{
+                //             return false
+                //         }
+                //     }
+                //     return currentType
+                // },
                 /**
                  * returns a sorted array of all the crops in the current logs. If area or type of seeding does not equal 'All' then the array will only contain crops that have the selected area and/or type of seeding
                  */ 
                 cropList(){
-                    let seedFilter = []
-                    if(this.selectedSeeding != 'All'){
-                        seedFilter = this.transplantingLogs.filter((x) => x.log_category[0].name === this.selectedSeeding)
-                    }
-                    else{
-                        seedFilter = this.transplantingLogs.filter((x) => x)
-                    }
                     let cropArray = []
                     if(this.selectedArea != 'All'){
-                        let areaFilter = seedFilter.filter((x) => x.movement.area[0].name === this.selectedArea)
+                        let areaFilter = this.transplantingLogs.filter((x) => x.movement.area[0].name === this.selectedArea)
                         cropArray = areaFilter.map(h => 
                             this.idToCropMap.get(h.data.crop_tid)
                         )
                     }
                     else{
-                        cropArray = seedFilter.map(h=> 
+                        cropArray = this.transplantingLogs.map(h=> 
                             this.idToCropMap.get(h.data.crop_tid)
                         )
                     }
@@ -393,55 +372,21 @@
                  * returns a sorted array of all the areas in the current logs. If a crop or type of seeding does not equal 'All' then the array will only contain areas that have the selected crop and/or type of seeding
                  */ 
                 areaList(){
-                    let seedFilter = []
-                    if(this.selectedSeeding != 'All'){
-                        seedFilter = this.transplantingLogs.filter((x) => x.log_category[0].name === this.selectedSeeding)
-                    }
-                    else{
-                        seedFilter = this.transplantingLogs.filter((x) => x)
-                    }
                     let areaArray = []
                     if(this.selectedCrop != 'All'){
-                        let cropFilter = seedFilter.filter((x) => this.idToCropMap.get(x.data.crop_tid) === this.selectedCrop)
+                        let cropFilter = this.transplantingLogs.filter((x) => this.idToCropMap.get(x.data.crop_tid) === this.selectedCrop)
                         areaArray = cropFilter.map(h =>
                             h.movement.area[0].name
                         )
                     }
                     else{
-                        areaArray = seedFilter.map(h =>
+                        areaArray = this.transplantingLogs.map(h =>
                             h.movement.area[0].name
                         )
                     }
                     let areas = new Set(areaArray)
                     let newAreaArray = Array.from(areas)
                     return newAreaArray.sort()
-                },
-                /**
-                 * returns a sorted array of all the types of seeding in the current logs. If the area or crop does not equal 'All' then the array will only contain types of seeding that have the selected area and/or crop
-                 */ 
-                seedingTypeList(){
-                    let areaFilter = []
-                    if(this.selectedArea != 'All'){
-                        areaFilter = this.transplantingLogs.filter((x) => x.movement.area[0].name === this.selectedArea)
-                    }
-                    else{
-                        areaFilter = this.transplantingLogs.filter((x) => x)
-                    }
-                    let seedingTypeArray = []
-                    if(this.selectedCrop != 'All'){
-                        let cropFilter = areaFilter.filter((x) => this.idToCropMap.get(x.data.crop_tid) === this.selectedCrop)
-                        seedingTypeArray = cropFilter.map(h =>
-                            h.log_category[0].name
-                        )
-                    }
-                    else{
-                        seedingTypeArray = areaFilter.map(h => 
-                            h.log_category[0].name
-                        )
-                    }
-                    let seedingsType = new Set(seedingTypeArray)
-                    let newSeedingTypeArray = Array.from(seedingsType)
-                    return newSeedingTypeArray.sort()
                 },
                 /**
                  * returns the total row feet for Direct Seeding
@@ -468,12 +413,12 @@
                 /**
                  * returns the total hours worked for direct seedings. Calculated by mulpitplying hours by workers for each log
                  */ 
-                totalDirectSeedingHours(){
+                totalHours(){
                     let tableData = this.tableRows
-                    let filteredTableData = tableData.filter((x) => x.data[3] === 'Direct')
                     let sumHours = 0
-                    filteredTableData.map(h => {
-                        sumHours = sumHours + h.data[10]//*h.data[11])
+                    tableData.map(h => {
+                        hours = parseFloat(h.data[9]);
+                        sumHours = sumHours + hours
                     })
                     return (Math.round(sumHours*100))/100
                 },
@@ -515,26 +460,26 @@
                     )
                     return (Math.round(totalTrays*100))/100
                 },
-                /**
-                 * returns the total hours worked for the Tray Seeding logs. Calculated by multiplying the hours and workers for each log
-                 */ 
-                totalTraySeedingHours(){
-                    let tableData = this.tableRows
-                    let filteredTableData = tableData.filter((x) => x.data[3] === 'Tray')
-                    let sumHours = 0
-                    filteredTableData.map(h => {
-                        sumHours = sumHours + (parseFloat(h.data[10])*parseFloat(h.data[11]))
-                    })
-                    return (Math.round(sumHours*100))/100
-                },
-                /**
-                 * returns the average amount of seeds planted per hour. Calculated by having the total seedings planted divided by the total hours worked
-                 */ 
-                aveSeedsPerHour(){
-                    let seedsPlanted = this.traySeedsPlanted
-                    let hours = this.totalTraySeedingHours
-                    return (Math.round((seedsPlanted/hours)*100))/100
-                },
+                // /**
+                //  * returns the total hours worked for the Tray Seeding logs. Calculated by multiplying the hours and workers for each log
+                //  */ 
+                // totalTraySeedingHours(){
+                //     let tableData = this.tableRows
+                //     let filteredTableData = tableData.filter((x) => x.data[3] === 'Tray')
+                //     let sumHours = 0
+                //     filteredTableData.map(h => {
+                //         sumHours = sumHours + (parseFloat(h.data[10])*parseFloat(h.data[11]))
+                //     })
+                //     return (Math.round(sumHours*100))/100
+                // },
+                // /**
+                //  * returns the average amount of seeds planted per hour. Calculated by having the total seedings planted divided by the total hours worked
+                //  */ 
+                // aveSeedsPerHour(){
+                //     let seedsPlanted = this.traySeedsPlanted
+                //     let hours = this.totalTraySeedingHours
+                //     return (Math.round((seedsPlanted/hours)*100))/100
+                // },
                 /**
                  * returns the structure for updating the quantity section of the Direct Seeding Logs. The values have not been updated yet.
                  */

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.spec.js
@@ -168,7 +168,7 @@ describe('Testing for the transplanting report page', () => {
         }) 
     })
 
-    context.only('assures filters are actually populated', () => {
+    context('assures filters are actually populated', () => {
 
         it('test if crops are correctly loaded to the filter dropdown', () => {
             cy.get('[data-cy=start-date-select]')
@@ -638,7 +638,7 @@ describe('Testing for the transplanting report page', () => {
         })
     })
 
-    context('edit and delete buttons work', () => {
+    context.only('edit and delete buttons work', () => {
         let logID = 0
 
         beforeEach(() => {
@@ -812,7 +812,7 @@ describe('Testing for the transplanting report page', () => {
         it('fail the session token API: outside of 2xx error code', () => {
             cy.intercept('GET', 'restws/session/token', { statusCode: 500 }).as('failedSessionTok')
 
-            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.visit('/farm/fd2-barn-kit/transplantingReport')
             cy.wait('@failedSessionTok')
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
@@ -827,7 +827,7 @@ describe('Testing for the transplanting report page', () => {
         it('fail the session token API: network error', () => {
             cy.intercept('GET', 'restws/session/token', { forceNetworkError: true }).as('failedSessionTok')
 
-            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.visit('/farm/fd2-barn-kit/transplantingReport')
             cy.wait('@failedSessionTok')
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
@@ -847,7 +847,7 @@ describe('Testing for the transplanting report page', () => {
         it('fail the crop map API: outside of 2xx error code', () => {
             cy.intercept('GET', 'taxonomy_term?bundle=farm_crops&page=1', { statusCode: 500 }).as('failedCropMap')
 
-            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.visit('/farm/fd2-barn-kit/transplantingReport')
             cy.wait('@failedCropMap')
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
@@ -862,7 +862,7 @@ describe('Testing for the transplanting report page', () => {
         it('fail the crop map API: network error', () => {
             cy.intercept('GET', 'taxonomy_term?bundle=farm_crops&page=1', { forceNetworkError: true }).as('failedCropMap')
 
-            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.visit('/farm/fd2-barn-kit/transplantingReport')
             cy.wait('@failedCropMap')
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
@@ -882,7 +882,7 @@ describe('Testing for the transplanting report page', () => {
         it('fail the user map API: outside of 2xx error code', () => {
             cy.intercept('GET', 'user', { statusCode: 500 }).as('failedUserMap')
 
-            cy.visit('/farm/fd2-barn-kit/seedingReport')         
+            cy.visit('/farm/fd2-barn-kit/transplantingReport')         
             cy.wait('@failedUserMap')
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
@@ -897,7 +897,7 @@ describe('Testing for the transplanting report page', () => {
         it('fail the user map API: network error', () => {
             cy.intercept('GET', 'user', { forceNetworkError: true }).as('failedUserMap')
 
-            cy.visit('/farm/fd2-barn-kit/seedingReport')         
+            cy.visit('/farm/fd2-barn-kit/transplantingReport')         
             cy.wait('@failedUserMap')
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
@@ -917,7 +917,7 @@ describe('Testing for the transplanting report page', () => {
         it('fail the area map API: outside of 2xx error code', () => {
             cy.intercept('GET', 'taxonomy_term.json?bundle=farm_areas', { statusCode: 500 }).as('failedAreaMap') 
 
-            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.visit('/farm/fd2-barn-kit/transplantingReport')
             cy.wait('@failedAreaMap')
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
@@ -932,7 +932,7 @@ describe('Testing for the transplanting report page', () => {
         it('fail the area map API: outside of network error', () => {
             cy.intercept('GET', 'taxonomy_term.json?bundle=farm_areas', { forceNetworkError: true }).as('failedAreaMap') 
 
-            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.visit('/farm/fd2-barn-kit/transplantingReport')
             cy.wait('@failedAreaMap')
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
@@ -952,7 +952,7 @@ describe('Testing for the transplanting report page', () => {
         it('fail the unit map API: outside of 2xx error code', () => {
             cy.intercept('GET', 'taxonomy_term.json?bundle=farm_quantity_units', { statusCode: 500 }).as('failedUnitMap')
 
-            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.visit('/farm/fd2-barn-kit/transplantingReport')
             cy.wait('@failedUnitMap')
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
@@ -967,7 +967,7 @@ describe('Testing for the transplanting report page', () => {
         it('fail the unit map API: network error', () => {
             cy.intercept('GET', 'taxonomy_term.json?bundle=farm_quantity_units', { forceNetworkError: true }).as('failedUnitMap')
 
-            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.visit('/farm/fd2-barn-kit/transplantingReport')
             cy.wait('@failedUnitMap')
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
@@ -1030,7 +1030,7 @@ describe('Testing for the transplanting report page', () => {
             cy.intercept('GET', 'taxonomy_term.json?bundle=farm_log_categories').as('logtypemap')            
             cy.intercept('GET', '/fd2_config/1').as('getConfigMap')       
             
-            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.visit('/farm/fd2-barn-kit/transplantingReport')
 
             cy.wait(['@cropmap', '@areamap', '@cropmap', '@usermap', '@areamap', '@unitmap',])
         })
@@ -1044,7 +1044,7 @@ describe('Testing for the transplanting report page', () => {
             cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')
             cy.get('[data-cy=end-date-select]')
-                .type('2019-03-01')
+                .type('2019-04-01')
             cy.get('[data-cy=generate-rpt-btn]')
                 .click()
             cy.get('[data-cy=h0]')
@@ -1054,28 +1054,20 @@ describe('Testing for the transplanting report page', () => {
             cy.get('[data-cy=h2]')
                 .should('have.text', 'Area')
             cy.get('[data-cy=h3]')
-                .should('have.text', 'Seeding')
+                .should('have.text', 'Bed Feet')
             cy.get('[data-cy=h4]')
-                .should('not.exist')
+                .should('have.text', 'Row Feet')
             cy.get('[data-cy=h5]')
-                .should('not.exist')
+                .should('have.text', 'Rows/Bed')
             cy.get('[data-cy=h6]')
-                .should('not.exist')
+                .should('have.text', 'Trays')
             cy.get('[data-cy=h7]')
-                .should('not.exist')
-            cy.get('[data-cy=h8]')
-                .should('not.exist')
-            cy.get('[data-cy=h9]')
-                .should('not.exist')
-            cy.get('[data-cy=h10]')
                 .should('have.text', 'Workers')
-            cy.get('[data-cy=h11]')
+            cy.get('[data-cy=h8]')
                 .should('have.text', 'Hours')
-            cy.get('[data-cy=h12]')
-                .should('have.text', 'Varieties')
-            cy.get('[data-cy=h13]')
+            cy.get('[data-cy=h9]')
                 .should('have.text', 'Comments')
-            cy.get('[data-cy=h14]')
+            cy.get('[data-cy=h10]')
                 .should('have.text', 'User')
             cy.get('[data-cy=edit-header]')
                 .should('have.text', 'Edit')
@@ -1100,38 +1092,30 @@ describe('Testing for the transplanting report page', () => {
             cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')
             cy.get('[data-cy=end-date-select]')
-                .type('2019-03-01')
+                .type('2019-04-01')
             cy.get('[data-cy=generate-rpt-btn]')
                 .click()
-            cy.get('[data-cy=h0]')
+                cy.get('[data-cy=h0]')
                 .should('have.text', 'Date')
             cy.get('[data-cy=h1]')
                 .should('have.text', 'Crop')
             cy.get('[data-cy=h2]')
                 .should('have.text', 'Area')
             cy.get('[data-cy=h3]')
-                .should('have.text', 'Seeding')
+                .should('have.text', 'Bed Feet')
             cy.get('[data-cy=h4]')
-                .should('not.exist')
+                .should('have.text', 'Row Feet')
             cy.get('[data-cy=h5]')
-                .should('not.exist')
+                .should('have.text', 'Rows/Bed')
             cy.get('[data-cy=h6]')
-                .should('not.exist')
+                .should('have.text', 'Trays')
             cy.get('[data-cy=h7]')
-                .should('not.exist')
-            cy.get('[data-cy=h8]')
-                .should('not.exist')
-            cy.get('[data-cy=h9]')
-                .should('not.exist')
-            cy.get('[data-cy=h10]')
                 .should('have.text', 'Workers')
-            cy.get('[data-cy=h11]')
+            cy.get('[data-cy=h8]')
                 .should('have.text', 'Hours')
-            cy.get('[data-cy=h12]')
-                .should('have.text', 'Varieties')
-            cy.get('[data-cy=h13]')
+            cy.get('[data-cy=h9]')
                 .should('have.text', 'Comments')
-            cy.get('[data-cy=h14]')
+            cy.get('[data-cy=h10]')
                 .should('have.text', 'User')
             cy.get('[data-cy=edit-header]')
                 .should('have.text', 'Edit')
@@ -1156,38 +1140,30 @@ describe('Testing for the transplanting report page', () => {
             cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')
             cy.get('[data-cy=end-date-select]')
-                .type('2019-03-01')
+                .type('2019-04-01')
             cy.get('[data-cy=generate-rpt-btn]')
                 .click()
-            cy.get('[data-cy=h0]')
+                cy.get('[data-cy=h0]')
                 .should('have.text', 'Date')
             cy.get('[data-cy=h1]')
                 .should('have.text', 'Crop')
             cy.get('[data-cy=h2]')
                 .should('have.text', 'Area')
             cy.get('[data-cy=h3]')
-                .should('have.text', 'Seeding')
+                .should('have.text', 'Bed Feet')
             cy.get('[data-cy=h4]')
-                .should('not.exist')
+                .should('have.text', 'Row Feet')
             cy.get('[data-cy=h5]')
-                .should('not.exist')
+                .should('have.text', 'Rows/Bed')
             cy.get('[data-cy=h6]')
-                .should('not.exist')
+                .should('have.text', 'Trays')
             cy.get('[data-cy=h7]')
                 .should('not.exist')
             cy.get('[data-cy=h8]')
                 .should('not.exist')
             cy.get('[data-cy=h9]')
-                .should('not.exist')
-            cy.get('[data-cy=h10]')
-                .should('not.exist')
-            cy.get('[data-cy=h11]')
-                .should('not.exist')
-            cy.get('[data-cy=h12]')
-                .should('have.text', 'Varieties')
-            cy.get('[data-cy=h13]')
                 .should('have.text', 'Comments')
-            cy.get('[data-cy=h14]')
+            cy.get('[data-cy=h10]')
                 .should('have.text', 'User')
             cy.get('[data-cy=edit-header]')
                 .should('have.text', 'Edit')

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.spec.js
@@ -431,13 +431,13 @@ describe('Testing for the transplanting report page', () => {
             .should('have.text', '92')
     
             cy.get('[data-cy=transplant-total-hours]')
-            .should('have.text', '29')
+            .should('have.text', '48.92')
 
             cy.get('[data-cy=transplant-total-rowft-hour]')
-            .should('have.text', '333.59')
+            .should('have.text', '197.75')
 
             cy.get('[data-cy=transplant-total-bedfr-hour]')
-            .should('have.text', '130.28')
+            .should('have.text', '77.23')
         })
     })
 
@@ -917,13 +917,13 @@ describe('Testing for the transplanting report page', () => {
             .should('have.text', '6')
 
             cy.get('[data-cy=transplant-total-hours]')
-            .should('have.text', '2')
+            .should('have.text', '6')
 
             cy.get('[data-cy=transplant-total-rowft-hour]')
-            .should('have.text', '4.5')
+            .should('have.text', '1.5')
 
             cy.get('[data-cy=transplant-total-bedfr-hour]')
-            .should('have.text', '1.5')
+            .should('have.text', '0.5')
             .then(() => {
                 cy.wrap(deleteRecord("/log/" + logID2 , sessionToken)).as('seedingDelete2')
             })
@@ -1130,7 +1130,7 @@ describe('Testing for the transplanting report page', () => {
         })
     })
 
-    context.only('edit and delete buttons work', () => {
+    context('edit and delete buttons work', () => {
         let logID = 0
 
         beforeEach(() => {
@@ -1231,7 +1231,6 @@ describe('Testing for the transplanting report page', () => {
                 cy.get('@create').should(function(response) {
                     expect(response.status).to.equal(201)
                     logID = response.body.id
-                    console.log(logID)
                 })
             })
             cy.get('[data-cy=start-date-select]')

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.spec.js
@@ -441,7 +441,7 @@ describe('Testing for the transplanting report page', () => {
         })
     })
 
-    context.only('has the correct totals in the seeding summary tables with hidden labor config', () => {
+    context('has the correct totals in the seeding summary tables with hidden labor config', () => {
         let logID = 0
         let logID2 = 0
         let logIDTransplant = 0
@@ -1130,158 +1130,7 @@ describe('Testing for the transplanting report page', () => {
         })
     })
 
-    // context.only('edit and delete buttons work', () => {
-    //     let logID = 0
-
-    //     beforeEach(() => {
-    //         cy.wrap(getSessionToken())
-    //         .then(sessionToken => {
-    //             token = sessionToken
-    //             req = {
-    //                 url: '/log',
-    //                 method: 'POST',
-    //                 headers: {
-    //                     'X-Requested-With': 'XMLHttpRequest',
-    //                     'X-CSRF-TOKEN' : token,
-    //                 },
-    //                 body: {
-    //                     "name": "TEST TRANSPLANTING",
-    //                     "type": "farm_transplanting",
-    //                     "timestamp": dayjs('2001-09-20').unix(),
-    //                     "done": "1",  //any seeding recorded is done.
-    //                     "notes": {
-    //                         "value": "This is a test log",
-    //                         "format": "farm_format"
-    //                     },
-    //                     "asset": [{ 
-    //                         "id": "1",   //Associated planting
-    //                         "resource": "farm_asset"
-    //                     }],
-    //                     "log_category": [{
-    //                         "id": "242",
-    //                         "resource": "taxonomy_term"
-    //                     }],
-    //                     "movement": {
-    //                         "area": [{
-    //                             "id": "233",
-    //                             "resource": "taxonomy_term"
-    //                         }]
-    //                     },
-    //                     "quantity": [
-    //                         {
-    //                             "measure": "length", 
-    //                             "value": "5",  //total row feet
-    //                             "unit": {
-    //                                 "id": "20", 
-    //                                 "resource": "taxonomy_term"
-    //                             },
-    //                             "label": "Amount planted"
-    //                         },
-    //                         {
-    //                             "measure": "ratio", 
-    //                             "value": "38",
-    //                             "unit": {
-    //                                 "id": "38",
-    //                                 "resource": "taxonomy_term"
-    //                             },
-    //                             "label": "Rows/Bed"
-    //                         },
-    //                         {
-    //                             "measure": "count", 
-    //                             "value": "2",
-    //                             "unit": {
-    //                                 "id": "12",
-    //                                 "resource": "taxonomy_term"
-    //                             },
-    //                             "label": "Flats"
-    //                         },         
-    //                         {
-    //                             "measure": "time", 
-    //                             "value": "0.5", 
-    //                             "unit": {
-    //                                 "id": "29",
-    //                                 "resource": "taxonomy_term"
-    //                             },
-    //                             "label": "Labor"
-    //                         },
-    //                         {
-    //                             "measure": "count", 
-    //                             "value": "1", 
-    //                             "unit": {
-    //                                 "id": "15",
-    //                                 "resource": "taxonomy_term"
-    //                             },
-    //                             "label": "Workers"
-    //                         },
-    //                     ],
-    //                     "created": dayjs().unix(),
-    //                     "data": "1"
-    //                 }
-    //             }
-
-    //             cy.request(req).as('create')
-    //             cy.get('@create').should(function(response) {
-    //                 expect(response.status).to.equal(201)
-    //                 logID = response.body.id
-    //             })
-    //         })
-
-    //         cy.get('[data-cy=start-date-select]')
-    //             .should('exist')
-    //             .type('2019-01-25')
-    //         cy.get('[data-cy=end-date-select]')
-    //             .should('exist')
-    //             .type('2019-05-25')
-    //         cy.get('[data-cy=generate-rpt-btn]').first()
-    //             .click()
-    //     })
-
-    //     it('edits the database when a row is edited in the table', () => {
-    //         cy.get('[data-cy=edit-button-r0]')
-    //             .click()   
-    //         cy.get('[data-cy=date-input-r0c0]')
-    //             .type('2001-09-28')  
-    //         cy.get('[data-cy=dropdown-input-r0c1]')
-    //             .select('TOMATO')
-    //         cy.get('[data-cy=dropdown-input-r0c2]')
-    //             .select('A')
-    //         cy.get('[data-cy=number-input-r0c3]')
-    //             .clear()
-    //             .type('40')
-    //         cy.get('[data-cy=number-input-r0c4]')
-    //             .clear()
-    //             .type('100')
-
-    //         // cy.get('[data-cy=text-input-r0c9]')
-    //         //     .clear()
-    //         //     .type('New Comment')
-    //         //     .blur()
-
-    //         // Button is actionable, unfortunately it's not in view
-    //         cy.get('[data-cy=save-button-r0]')
-    //             .click({force:true})
-
-    //         cy.wrap(getRecord('/log.json?type=farm_transplanting&id=' + logID)).as('check')
-    //         cy.get('@check').should(function(response) {
-    //             expect(response.data.list[0].name).to.equal('TEST TRANSPLANTING')
-    //         })
-    //             .then(() => {
-    //                 cy.wrap(deleteRecord("/log/" + logID , token)).as('transplantingDelete')
-    //             })
-    //         cy.get('@transplantingDelete').should((response) => {
-    //             expect(response.status).to.equal(200)
-    //         })
-    //     })
-
-    //     it('deletes a log from the database when the delete button is pressed', () => {
-    //         cy.get('[data-cy=delete-button-r0]')
-    //             .click((response) => {
-    //                 expect(response.status).to.equal(200)
-    //             })
-    //     })
-    // })
-
-    context('edit and delete buttons work', () => {
+    context.only('edit and delete buttons work', () => {
         let logID = 0
 
         beforeEach(() => {
@@ -1400,21 +1249,21 @@ describe('Testing for the transplanting report page', () => {
                 .click()   
             cy.get('[data-cy=date-input-r0c0]')
                 .type('2001-09-28')  
-            // cy.get('[data-cy=dropdown-input-r0c1]')
-            //     .select('TOMATO')
-            // cy.get('[data-cy=dropdown-input-r0c2]')
-            //     .select('A')
+            cy.get('[data-cy=dropdown-input-r0c1]')
+                .select('TOMATO')
+            cy.get('[data-cy=dropdown-input-r0c2]')
+                .select('A')
             cy.get('[data-cy=number-input-r0c3]')
                 .clear()
                 .type('40')
-            // cy.get('[data-cy=number-input-r0c4]')
-            //     .clear()
-            //     .type('100')
+            cy.get('[data-cy=number-input-r0c4]')
+                .clear()
+                .type('100')
 
-            // cy.get('[data-cy=text-input-r0c9]')
-            //     .clear()
-            //     .type('New Comment')
-            //     .blur()
+            cy.get('[data-cy=text-input-r0c9]')
+                .clear()
+                .type('New Comment')
+                .blur()
 
             // Button is actionable, unfortunately it's not in view
             cy.get('[data-cy=save-button-r0]')
@@ -1539,7 +1388,7 @@ describe('Testing for the transplanting report page', () => {
                 .then(() => {
                     cy.get('[data-cy=alert-err-handler]')
                     .should('be.visible')
-                    cy.window().its('scrollY').should('equal', 0)
+                    cy.window().its('scrollY').should('equal', 78)
                     cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
@@ -1598,15 +1447,7 @@ describe('Testing for the transplanting report page', () => {
                     cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
-                    .then(() => {
-                        cy.get('[data-cy=alert-err-handler]')
-                        .should('be.visible')
-                        cy.window().its('scrollY').should('equal', 0)
-                        cy.get('[data-cy=alert-err-handler]')
-                        .click()
-                        .should('not.visible')
-                    }) 
-            })
+            }) 
         })
     
             it('fail the session token API: network error', () => {

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.spec.js
@@ -655,7 +655,7 @@ describe('Testing for the transplanting report page', () => {
                     body: {
                         "name": "TEST TRANSPLANTING",
                         "type": "farm_transplanting",
-                        "timestamp": dayjs('2019-01-20').unix(),
+                        "timestamp": dayjs('2001-09-20').unix(),
                         "done": "1",  //any seeding recorded is done.
                         "notes": {
                             "value": "This is a test log",
@@ -677,63 +677,52 @@ describe('Testing for the transplanting report page', () => {
                         },
                         "quantity": [
                             {
-                                "measure": "length",
-                                "value": "150",
+                                "measure": "length", 
+                                "value": "5",  //total row feet
                                 "unit": {
-                                    "uri": "http://localhost/taxonomy_term/20",
-                                    "id": "20",
-                                    "resource": "taxonomy_term",
-                                    "name": "ROW FEET"
+                                    "id": "20", 
+                                    "resource": "taxonomy_term"
                                 },
                                 "label": "Amount planted"
                             },
                             {
-                                "measure": "ratio",
-                                "value": "5",
+                                "measure": "ratio", 
+                                "value": "38",
                                 "unit": {
-                                    "uri": "http://localhost/taxonomy_term/38",
                                     "id": "38",
-                                    "resource": "taxonomy_term",
-                                    "name": "ROWS/BED"
+                                    "resource": "taxonomy_term"
                                 },
                                 "label": "Rows/Bed"
                             },
                             {
-                                "measure": "count",
-                                "value": "4",
+                                "measure": "count", 
+                                "value": "10",
                                 "unit": {
-                                    "uri": "http://localhost/taxonomy_term/12",
-                                    "id": "12",
-                                    "resource": "taxonomy_term",
-                                    "name": "FLATS"
+                                    "id": "10",
+                                    "resource": "taxonomy_term"
                                 },
                                 "label": "Flats"
-                            },
+                            },         
                             {
-                                "measure": "time",
-                                "value": "2",
+                                "measure": "time", 
+                                "value": "0.5", 
                                 "unit": {
-                                    "uri": "http://localhost/taxonomy_term/29",
                                     "id": "29",
-                                    "resource": "taxonomy_term",
-                                    "name": "HOURS"
+                                    "resource": "taxonomy_term"
                                 },
                                 "label": "Labor"
                             },
                             {
-                                "measure": "count",
-                                "value": "1",
+                                "measure": "count", 
+                                "value": "1", 
                                 "unit": {
-                                    "uri": "http://localhost/taxonomy_term/15",
                                     "id": "15",
-                                    "resource": "taxonomy_term",
-                                    "name": "PEOPLE"
+                                    "resource": "taxonomy_term"
                                 },
                                 "label": "Workers"
                             },
                         ],
                         "created": dayjs().unix(),
-                        "lot_number": "N/A (No Variety)",
                         "data": "1"
                     }
                 }
@@ -750,7 +739,7 @@ describe('Testing for the transplanting report page', () => {
                 .type('2019-01-25')
             cy.get('[data-cy=end-date-select]')
                 .should('exist')
-                .type('2019-04-01')
+                .type('2019-05-25')
             cy.get('[data-cy=generate-rpt-btn]').first()
                 .click()
         })
@@ -765,19 +754,16 @@ describe('Testing for the transplanting report page', () => {
             cy.get('[data-cy=dropdown-input-r0c2]')
                 .select('A')
             cy.get('[data-cy=number-input-r0c3]')
+                .clear()
                 .type('40')
             cy.get('[data-cy=number-input-r0c4]')
-                .type('120')
-            cy.get('[data-cy=number-input-r0c6]')
-                .type('6')
-            cy.get('[data-cy=number-input-r0c7]')
-                .type('2')
-            cy.get('[data-cy=number-input-r0c8]')
-                .type('3.00')
+                .clear()
+                .type('100')
 
-            cy.get('[data-cy=text-input-r0c9]')
-                .type('New Comment')
-                .blur()
+            // cy.get('[data-cy=text-input-r0c9]')
+            //     .clear()
+            //     .type('New Comment')
+            //     .blur()
 
             // Button is actionable, unfortunately it's not in view
             cy.get('[data-cy=save-button-r0]')
@@ -785,12 +771,12 @@ describe('Testing for the transplanting report page', () => {
 
             cy.wrap(getRecord('/log.json?type=farm_transplanting&id=' + logID)).as('check')
             cy.get('@check').should(function(response) {
-                expect(response.data.list[0].name).to.equal('TEST SEEDING')
+                expect(response.data.list[0].name).to.equal('TEST TRANSPLANTING')
             })
                 .then(() => {
-                    cy.wrap(deleteRecord("/log/" + logID , token)).as('seedingDelete')
+                    cy.wrap(deleteRecord("/log/" + logID , token)).as('transplantingDelete')
                 })
-            cy.get('@seedingDelete').should((response) => {
+            cy.get('@transplantingDelete').should((response) => {
                 expect(response.status).to.equal(200)
             })
         })

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.spec.js
@@ -1,0 +1,1530 @@
+const dayjs = require('dayjs')
+var FarmOSAPI = require('../resources/FarmOSAPI.js')
+var getSessionToken = FarmOSAPI.getSessionToken
+var getCropToIDMap = FarmOSAPI.getCropToIDMap
+var getIDToCropMap = FarmOSAPI.getIDToCropMap
+var getAreaToIDMap = FarmOSAPI.getAreaToIDMap
+var getUserToIDMap = FarmOSAPI.getUserToIDMap
+var getUnitToIDMap = FarmOSAPI.getUnitToIDMap
+var createRecord = FarmOSAPI.createRecord
+var getRecord = FarmOSAPI.getRecord
+var deleteRecord = FarmOSAPI.deleteRecord
+var getConfiguration = FarmOSAPI.getConfiguration
+var setConfiguration = FarmOSAPI.setConfiguration
+
+describe('Testing for the seeding report page', () => {
+    let cropToIDMap = null
+    let IDToCropMap = null
+    let areaToIDMap = null
+    let userToIDMap = null
+    let unitToIDMap = null
+    let defaultConfig = null
+    let testConfig = { id: "1", labor: 'Required' }
+
+    beforeEach(() => {
+        cy.login('manager1', 'farmdata2')
+            .then(() => {
+                // Using wrap to wait for the asynchronus API request.
+                cy.wrap(getCropToIDMap()).as('cropMap')
+                cy.wrap(getAreaToIDMap()).as('areaMap')
+                cy.wrap(getIDToCropMap()).as('IDCropMap')
+                cy.wrap(getUserToIDMap()).as('userMap')
+                cy.wrap(getUnitToIDMap()).as('unitMap')
+            })
+        // Wait here for the maps in the tests.
+        cy.get('@cropMap').should(function(map) {
+            cropToIDMap = map
+        })
+        cy.get('@areaMap').should(function(map) {
+            areaToIDMap = map
+        })
+        cy.get('@IDCropMap').should(function(map) {
+            IDToCropMap = map
+        })
+        cy.get('@userMap').should(function(map) {
+            userToIDMap = map
+        })
+        cy.get('@unitMap').should(function(map) {
+            unitToIDMap = map
+        })
+        
+        // Setting up wait for the request in the created() to complete.
+        cy.intercept('GET', 'taxonomy_term?bundle=farm_crops&page=1').as('cropmap')
+        cy.intercept('GET', 'taxonomy_term.json?bundle=farm_areas').as('areamap') 
+        cy.intercept('GET', '/taxonomy_term.json?bundle=farm_crops').as('IDCropMap')
+        cy.intercept('GET', 'user').as('userMap') 
+        cy.intercept('GET', 'taxonomy_term.json?bundle=farm_quantity_units').as('unitMap') 
+        
+        // cy.restoreLocalStorage()
+        cy.visit('/farm/fd2-barn-kit/seedingReport')
+    
+        // Wait here for the maps to load in the page.   
+        cy.wait(['@cropmap', '@areamap', '@IDCropMap', '@userMap', '@unitMap'])
+    })
+
+    context('can set dates and then render the report', () => {
+
+        it('allows user input of the start and end dates', () => {
+            cy.get('[data-cy=date-range-selection]')
+                .should('exist')
+
+            cy.get('[data-cy=start-date-select]')
+                .should('exist')
+                .type('2019-01-01')
+
+            cy.get('[data-cy=end-date-select]')
+                .should('exist')
+                .type('2019-03-01')
+                
+            cy.get('[data-cy=date-select]')
+                .each(($el, index, $all) => {
+                    if (index == 0) {
+                        expect($el).to.have.value('2019-01-01')
+                    }
+                    else if (index == 1){
+                        expect($el).to.have.value('2019-03-01')
+                    }
+                })
+        })
+
+        it('generate report button renders the rest of the page', () => {
+            cy.get('[data-cy=generate-rpt-btn]')
+                .click()
+
+            cy.get('[data-cy=filters-panel]')
+                .should('exist')
+
+            cy.get('[data-cy=report-table]')
+                .should('exist')
+
+            cy.get('[data-cy=direct-summary]')
+                .should('exist')
+
+            cy.get('[data-cy=tray-summary]')
+                .should('exist')
+        })
+
+        it('generate report experiences API error: outside of 2xx error code', () => {
+            cy.get('[data-cy=date-range-selection]')
+                .should('exist')
+            cy.get('[data-cy=start-date-select]')
+                .should('exist')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .should('exist')
+                .type('2019-03-01')
+
+            cy.intercept('GET', '/log.json?type=farm_seeding&timestamp[ge]=1546300800&timestamp[le]=1551398400', { statusCode: 500 })
+            .as('getAPIFailure')
+            cy.get('[data-cy=generate-rpt-btn]')
+                .click()
+            cy.wait('@getAPIFailure')
+            .then(() => {
+                cy.get('[data-cy=alert-err-handler]')
+                cy.window().its('scrollY').should('equal', 0)
+                cy.get('[data-cy=alert-err-handler]')
+                .should('be.visible')
+                .click()
+                .should('not.visible')
+            }) 
+            cy.get('[data-cy=filters-panel]')
+                .should('not.exist')
+
+            cy.get('[data-cy=report-table]')
+                .should('not.exist')
+
+            cy.get('[data-cy=direct-summary]')
+                .should('not.exist')
+
+            cy.get('[data-cy=tray-summary]')
+                .should('not.exist')
+        }) 
+
+        it('generate report experiences API error: network error', () => {
+            cy.get('[data-cy=date-range-selection]')
+                .should('exist')
+            cy.get('[data-cy=start-date-select]')
+                .should('exist')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .should('exist')
+                .type('2019-03-01')
+
+            cy.intercept('GET', '/log.json?type=farm_seeding&timestamp[ge]=1546300800&timestamp[le]=1551398400', { forceNetworkError: true })
+            .as('getAPIFailure')
+            cy.get('[data-cy=generate-rpt-btn]')
+                .click()
+            cy.wait('@getAPIFailure')
+            .then(() => {
+                cy.get('[data-cy=alert-err-handler]')
+                cy.window().its('scrollY').should('equal', 0)
+                cy.get('[data-cy=alert-err-handler]')
+                .should('be.visible')
+                .click()
+                .should('not.visible')
+            }) 
+            cy.get('[data-cy=filters-panel]')
+                .should('not.exist')
+
+            cy.get('[data-cy=report-table]')
+                .should('not.exist')
+
+            cy.get('[data-cy=direct-summary]')
+                .should('not.exist')
+
+            cy.get('[data-cy=tray-summary]')
+                .should('not.exist')
+        }) 
+    })
+
+    context('assures filters are actually populated', () => {
+
+        it('test if seeding type are correctly loaded to the filter dropdown', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .children() 
+                .first()
+                .should('have.value', 'All')
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .children() 
+                .first()  
+                .next()
+                .should('have.value', 'Direct Seedings')
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .children() 
+                .last()
+                .should('have.value', 'Tray Seedings')
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .children() 
+                .should('have.length', '3')
+        })
+
+        it('test if crops are correctly loaded to the filter dropdown', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+
+            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
+                .children() 
+                .first()
+                .should('have.value', 'All')
+            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
+                .children() 
+                .first()  
+                .next()
+                .should('have.value', 'ARUGULA')
+            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
+                .children() 
+                .last()
+                .should('have.value', 'SCALLION')
+            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
+                .children() 
+                .should('have.length', '22')
+        })
+
+        it('test if areas are correctly loaded to the filter dropdown', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+
+            cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
+                .children() 
+                .first()
+                .should('have.value', 'All')
+            cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
+                .children() 
+                .first()  
+                .next()
+                .should('have.value', 'A')
+            cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
+                .children() 
+                .last()
+                .should('have.value', 'SEEDING BENCH')
+            cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
+                .children() 
+                .should('have.length', '12')
+        })
+    })
+
+    context('can see spinner at appropriate times', () => {
+
+        it('show spinner after input', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+            cy.get('[data-cy=loader]').should('be.visible')
+        })
+
+        it('spinner dissappears after whole response returns 1 page', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-02-01')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+            cy.get('[data-cy=report-table]').find('tr').its('length').then(length =>{
+                expect(length).to.equal(3)
+                cy.get('[data-cy=loader]').should('not.exist')
+            }) 
+        })
+
+        it('spinner reappears after changing values and clicking again', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-03')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+            cy.get('[data-cy=loader]').should('be.visible')
+        })
+    })
+
+    context('clicking on date ranges hides report', () => {
+        beforeEach(() => {
+            //cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+            cy.get('[data-cy=generate-rpt-btn]')
+                .click()
+        })
+
+        it('clicking on start date range hides report', () => {
+            cy.get('[data-cy=report-table]').should('exist')
+            cy.get('[data-cy=start-date-select]').click()
+
+            cy.get('[data-cy=generate-rpt-btn]')
+                .should('exist')
+            cy.get('[data-cy=filters-panel]')
+                .should('not.exist')
+            cy.get('[data-cy=report-table]')
+                .should('not.exist')
+            cy.get('[data-cy=direct-summary]')
+                .should('not.exist')
+            cy.get('[data-cy=tray-summary]')
+                .should('not.exist')
+        })
+
+        it('clicking on end date range hides report', () => {
+            cy.get('[data-cy=report-table]').should('exist')
+            cy.get('[data-cy=end-date-select]').click()
+
+            cy.get('[data-cy=generate-rpt-btn]')
+                .should('exist')
+            cy.get('[data-cy=filters-panel]')
+                .should('not.exist')
+            cy.get('[data-cy=report-table]')
+                .should('not.exist')
+            cy.get('[data-cy=direct-summary]')
+                .should('not.exist')
+            cy.get('[data-cy=tray-summary]')
+                .should('not.exist')
+        })
+    })
+
+    context('can see No Logs message at appropriate times', () => {
+
+        it('the No Logs message does not appear with a table with logs', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+            cy.get('[data-cy=no-logs-message]').should('not.exist')
+        })
+
+        it('the No Logs message appears with a table with no logs', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2021-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2021-03-01')
+            cy.get('[data-cy=generate-rpt-btn]').click()
+            cy.get('[data-cy=no-logs-message]').should('be.visible')
+        })
+    })
+
+    context('can see summary tables at appropriate times and displays appropriate message', () => {
+        beforeEach(() => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+            cy.get('[data-cy=generate-rpt-btn]')
+                .click()
+        })
+
+        it('does not immediately display summary tables', () => {
+            cy.get('[data-cy=tray-summary]').should('not.exist')
+            cy.get('[data-cy=direct-summary]').should('not.exist')
+        })
+
+        it('shows summary tables after table is fully loaded', () => {
+            cy.get('[data-cy=report-table]')
+            cy.get('[data-cy=tray-summary]',).should('be.visible')
+            cy.get('[data-cy=direct-summary]').should('be.visible')
+        }) 
+
+        it('show tray seeding message when only direct seeding', () => {
+            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
+                .select('CARROT')
+            cy.get('[data-cy=tray-no-logs')
+                .should('have.text', 'There are no Tray Seeding logs with these parameters')
+        })
+
+        it('show direct seeding message when only tray seeding', () => {
+            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
+                .select('BOKCHOY')
+            cy.get('[data-cy=direct-no-logs')
+                .should('have.text', 'There are no Direct Seeding logs with these parameters')
+            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
+                .select('All')
+        })
+
+        it('show one summary table with specific seeding type', () => {
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+            .select('Direct Seedings')
+            cy.get('[data-cy=direct-summary').should('exist')
+            cy.get('[data-cy=tray-summary]').should('not.exist')
+
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+            .select('Tray Seedings')
+            cy.get('[data-cy=direct-summary').should('not.exist')
+            cy.get('[data-cy=tray-summary]').should('exist')
+        })
+    })
+
+    context('displays the right information in the table', () => {
+        beforeEach(() => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+            cy.get('[data-cy=generate-rpt-btn]')
+                .click()
+
+            cy.get('[data-cy=report-table]').find('tr').its('length')
+                .then(length =>{
+                    expect(length).to.equal(35)
+                })
+        })
+
+        it('requests and displays logs that fall between the specified dates', () => {
+            let currentTimestamp = null
+            const startTimestamp = dayjs('2019-01-01').unix()
+            const endTimestamp = dayjs('2019-03-01').unix()
+
+            for(let r = 0; r < 34; r++){
+                cy.get('[data-cy=r' + r + 'c0')
+                    .invoke('text')
+                    .then(dateText => {
+                        currentTimestamp = dayjs(dateText).unix()
+                        expect(currentTimestamp).is.within(startTimestamp, endTimestamp)
+                    })
+            }
+        })
+
+        it('filters by type of seeding', () => {
+            let typeSeeding = null
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .select('Direct Seedings')
+                .should('have.value', 'Direct Seedings')
+
+            for(let r = 0; r < 7; r++){
+                cy.get('[data-cy=r' + r + 'c3')
+                    .invoke('text')
+                    .then(seeding => {
+                        typeSeeding = seeding
+                        expect(typeSeeding, 'Direct')
+                    })
+            }
+
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .select('Tray Seedings')
+                .should('have.value', 'Tray Seedings')
+
+            for(let r = 0; r < 27; r++){
+                cy.get('[data-cy=r' + r + 'c3')
+                    .invoke('text')
+                    .then(seeding => {
+                        typeSeeding = seeding
+                        expect(typeSeeding, 'Tray')
+                    })
+            }
+
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .select('All')
+                .should('have.value', 'All')
+        })
+
+        it('filters by crop', () => {
+            let crop = null
+            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
+                .select('LEEK')
+                .should('have.value', 'LEEK')
+
+
+            for(let r = 0; r < 3; r++){
+                cy.get('[data-cy=r' + r + 'c1')
+                    .invoke('text')
+                    .then(actualCrop => {
+                        crop = actualCrop
+                        expect(crop, 'LEEK')
+                    })
+            }
+
+            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
+                .select('All')
+                .should('have.value', 'All')
+        })
+
+        it('filters by field', () => {
+            let area = null
+            cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
+                .select('CHUAU')
+                .should('have.value', 'CHUAU')
+
+            for(let r = 0; r < 8; r++){
+                cy.get('[data-cy=r' + r + 'c2')
+                    .invoke('text')
+                    .then(actualArea => {
+                        area = actualArea
+                        expect(area, 'CHUAU')
+                    })
+            }
+            
+            cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
+                .select('All')
+                .should('have.value', 'All')
+            })
+        })
+
+    context('has the correct totals in the seeding summary tables', () => {
+        beforeEach(() => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+            cy.get('[data-cy=generate-rpt-btn]')
+                .click()
+        })
+
+        it('verify all values in the direct seeding summary', () => {
+            cy.get('[data-cy=direct-total-rowft]')
+            .should('have.text', '26177')
+
+            cy.get('[data-cy=direct-total-bedft]')
+            .should('have.text', '8803')
+
+            cy.get('[data-cy=direct-total-hours]')
+            .should('have.text', '7')
+
+            cy.get('[data-cy=direct-total-rowft-hour]')
+            .should('have.text', '3739.57')
+
+            cy.get('[data-cy=direct-total-bedfr-hour]')
+            .should('have.text', '1257.57')
+            })
+
+        it('verify all values in the tray seeding summary', () => {
+            cy.get('[data-cy=tray-total-seeds]')
+            .should('have.text', '16808')
+    
+            cy.get('[data-cy=tray-total-trays]')
+            .should('have.text', '212.5')
+    
+            cy.get('[data-cy=tray-total-seeds-hour]')
+            .should('have.text', '20.1')
+    
+            cy.get('[data-cy=tray-avg-seeds-hour]')
+            .should('have.text', '836.22')
+        })
+    })
+
+    context('changing the type of seeding changes the visible columns', () => {
+        beforeEach(() => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+            cy.get('[data-cy=generate-rpt-btn]')
+                .click()
+        })
+
+        it('displays only columns relevant to both seedings when "All" is selected', () => {
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .should('have.value', 'All')
+            cy.get('[data-cy=h0]')
+                .should('have.text', 'Date')
+            cy.get('[data-cy=h1]')
+                .should('have.text', 'Crop')
+            cy.get('[data-cy=h2]')
+                .should('have.text', 'Area')
+            cy.get('[data-cy=h3]')
+                .should('have.text', 'Seeding')
+            cy.get('[data-cy=h4]')
+                .should('not.exist')
+            cy.get('[data-cy=h5]')
+                .should('not.exist')
+            cy.get('[data-cy=h6]')
+                .should('not.exist')
+            cy.get('[data-cy=h7]')
+                .should('not.exist')
+            cy.get('[data-cy=h8]')
+                .should('not.exist')
+            cy.get('[data-cy=h9]')
+                .should('not.exist')
+            cy.get('[data-cy=h10]')
+                .should('have.text', 'Workers')
+            cy.get('[data-cy=h11]')
+                .should('have.text', 'Hours')
+            cy.get('[data-cy=h12]')
+                .should('have.text', 'Varieties')
+            cy.get('[data-cy=h13]')
+                .should('have.text', 'Comments')
+            cy.get('[data-cy=h14]')
+                .should('have.text', 'User')
+            cy.get('[data-cy=edit-header]')
+                .should('have.text', 'Edit')
+            cy.get('[data-cy=delete-header]')
+                .should('have.text', 'Delete')
+        })
+
+        it('displays columns relevant to direct seedings when "Direct Seedings" is selected', () => {
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .select('Direct Seedings')
+                .should('have.value', 'Direct Seedings')
+            cy.get('[data-cy=h0]')
+                .should('have.text', 'Date')
+            cy.get('[data-cy=h1]')
+                .should('have.text', 'Crop')
+            cy.get('[data-cy=h2]')
+                .should('have.text', 'Area')
+            cy.get('[data-cy=h3]')
+                .should('have.text', 'Seeding')
+            cy.get('[data-cy=h4]')
+                .should('have.text', 'Row Feet')
+            cy.get('[data-cy=h5]')
+                .should('have.text', 'Bed Feet')
+            cy.get('[data-cy=h6]')
+                .should('have.text', 'Rows/Bed')
+            cy.get('[data-cy=h7]')
+                .should('not.exist')
+            cy.get('[data-cy=h8]')
+                .should('not.exist')
+            cy.get('[data-cy=h9]')
+                .should('not.exist')
+            cy.get('[data-cy=h10]')
+                .should('have.text', 'Workers')
+            cy.get('[data-cy=h11]')
+                .should('have.text', 'Hours')
+            cy.get('[data-cy=h12]')
+                .should('have.text', 'Varieties')
+            cy.get('[data-cy=h13]')
+                .should('have.text', 'Comments')
+            cy.get('[data-cy=h14]')
+                .should('have.text', 'User')
+            cy.get('[data-cy=edit-header]')
+                .should('have.text', 'Edit')
+            cy.get('[data-cy=delete-header]')
+                .should('have.text', 'Delete')
+            cy.get('[data-cy=save-header]')
+                .should('not.exist')
+            cy.get('[data-cy=cancel-header]')
+                .should('not.exist')
+        })
+
+        it('displays columns relevant to direct seedings when "Direct Seedings" is selected and in edit mode', () => {
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .select('Direct Seedings')
+                .should('have.value', 'Direct Seedings')
+            cy.get('[data-cy=edit-button-r0]').first()
+                .click()
+            cy.get('[data-cy=h0]')
+                .should('have.text', 'Date')
+            cy.get('[data-cy=h1]')
+                .should('have.text', 'Crop')
+            cy.get('[data-cy=h2]')
+                .should('have.text', 'Area')
+            cy.get('[data-cy=h3]')
+                .should('have.text', 'Seeding')
+            cy.get('[data-cy=h4]')
+                .should('have.text', 'Row Feet')
+            cy.get('[data-cy=h5]')
+                .should('have.text', 'Bed Feet')
+            cy.get('[data-cy=h6]')
+                .should('have.text', 'Rows/Bed')
+            cy.get('[data-cy=h7]')
+                .should('not.exist')
+            cy.get('[data-cy=h8]')
+                .should('not.exist')
+            cy.get('[data-cy=h9]')
+                .should('not.exist')
+            cy.get('[data-cy=h10]')
+                .should('have.text', 'Workers')
+            cy.get('[data-cy=h11]')
+                .should('have.text', 'Hours')
+            cy.get('[data-cy=h12]')
+                .should('have.text', 'Varieties')
+            cy.get('[data-cy=h13]')
+                .should('have.text', 'Comments')
+            cy.get('[data-cy=h14]')
+                .should('have.text', 'User')
+            cy.get('[data-cy=edit-header]')
+                .should('not.exist')
+            cy.get('[data-cy=delete-header]')
+                .should('not.exist')
+            cy.get('[data-cy=save-header]')
+                .should('have.text', 'Save')
+            cy.get('[data-cy=cancel-header]')
+                .should('have.text', 'Cancel')
+
+            //Force the action to occur because in the viewport isn't big enough for the 
+            //button to be clickable
+            cy.get('[data-cy=cancel-button-r0]')
+                .click({force:true})
+        })
+
+        it('displays columns relevant to tray seedings when "Tray Seedings" is selected', () => {
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .select('Tray Seedings')
+                .should('have.value', 'Tray Seedings')
+                cy.get('[data-cy=h1]')
+                .should('have.text', 'Crop')
+            cy.get('[data-cy=h2]')
+                .should('have.text', 'Area')
+            cy.get('[data-cy=h3]')
+                .should('have.text', 'Seeding')
+            cy.get('[data-cy=h4]')
+                .should('not.exist')
+            cy.get('[data-cy=h5]')
+                .should('not.exist')
+            cy.get('[data-cy=h6]')
+                .should('not.exist')
+            cy.get('[data-cy=h7]')
+                .should('have.text', 'Seeds')
+            cy.get('[data-cy=h8]')
+                .should('have.text', 'Trays')
+            cy.get('[data-cy=h9]')
+                .should('have.text', 'Cells/Tray')
+            cy.get('[data-cy=h10]')
+                .should('have.text', 'Workers')
+            cy.get('[data-cy=h11]')
+                .should('have.text', 'Hours')
+            cy.get('[data-cy=h12]')
+                .should('have.text', 'Varieties')
+            cy.get('[data-cy=h13]')
+                .should('have.text', 'Comments')
+            cy.get('[data-cy=h14]')
+                .should('have.text', 'User')
+            cy.get('[data-cy=edit-header]')
+                .should('have.text', 'Edit')
+            cy.get('[data-cy=delete-header]')
+                .should('have.text', 'Delete')
+            cy.get('[data-cy=save-header]')
+                .should('not.exist')
+            cy.get('[data-cy=cancel-header]')
+                .should('not.exist')
+        })
+
+        it('displays columns relevant to tray seedings when "Tray Seedings" is selected and in edit mode', () => {
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .select('Tray Seedings')
+                .should('have.value', 'Tray Seedings')
+            cy.get('[data-cy=edit-button-r0]').first()
+                .click()
+            cy.get('[data-cy=h1]')
+                .should('have.text', 'Crop')
+            cy.get('[data-cy=h2]')
+                .should('have.text', 'Area')
+            cy.get('[data-cy=h3]')
+                .should('have.text', 'Seeding')
+            cy.get('[data-cy=h4]')
+                .should('not.exist')
+            cy.get('[data-cy=h5]')
+                .should('not.exist')
+            cy.get('[data-cy=h6]')
+                .should('not.exist')
+            cy.get('[data-cy=h7]')
+                .should('have.text', 'Seeds')
+            cy.get('[data-cy=h8]')
+                .should('have.text', 'Trays')
+            cy.get('[data-cy=h9]')
+                .should('have.text', 'Cells/Tray')
+            cy.get('[data-cy=h10]')
+                .should('have.text', 'Workers')
+            cy.get('[data-cy=h11]')
+                .should('have.text', 'Hours')
+            cy.get('[data-cy=h12]')
+                .should('have.text', 'Varieties')
+            cy.get('[data-cy=h13]')
+                .should('have.text', 'Comments')
+            cy.get('[data-cy=h14]')
+                .should('have.text', 'User')
+            cy.get('[data-cy=edit-header]')
+                .should('not.exist')
+            cy.get('[data-cy=delete-header]')
+                .should('not.exist')
+            cy.get('[data-cy=save-header]')
+                .should('have.text', 'Save')
+
+            cy.get('[data-cy=cancel-header]')
+                .should('have.text', 'Cancel')
+
+            //Force the action to occur because in the viewport isn't big enough for the 
+            //button to be clickable
+            cy.get('[data-cy=cancel-button-r0]')
+                .click({force:true})
+        })
+    })
+
+    context('date picker and filter behavior', () => {
+        beforeEach(() => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-02-13')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-02-16')
+            cy.get('[data-cy=generate-rpt-btn]')
+                .click()
+        })
+
+        it('updates crop and area options when a new seeding type has been selected', () => {
+            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
+                .children()
+                    .first()
+                        .should('have.value', 'All')
+                    .next()
+                        .should('have.value', 'ARUGULA')
+                    .next()
+                        .should('have.value', 'CARROT')
+                    .next()
+                        .should('have.value', 'CHARD')
+                    .next()
+                        .should('have.value', 'ONION-FRESH')
+                    .next()
+                        .should('have.value', 'SCALLION')
+
+            cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
+                .children()
+                    .first()
+                        .should('have.value', 'All')
+                    .next()
+                        .should('have.value', 'A')
+                    .next()
+                        .should('have.value', 'CHUAU')
+                    .next()
+                        .should('have.value', 'CHUAU-3')
+                    .next()
+                        .should('have.value', 'SEEDING BENCH')
+
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .select('Tray Seedings')
+                .should('have.value', 'Tray Seedings')
+
+            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
+                .children()
+                    .first()
+                        .should('have.value', 'All')
+                    .next()
+                        .should('have.value', 'CHARD')
+                    .next()
+                        .should('have.value', 'ONION-FRESH')
+                    .next()
+                        .should('have.value', 'SCALLION')
+
+            cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
+                .children()
+                    .first()
+                        .should('have.value', 'All')
+                    .next()
+                        .should('have.value', 'CHUAU')
+                    .next()
+                        .should('have.value', 'SEEDING BENCH')
+
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .select('All')
+                .should('have.value', 'All')
+
+        })
+
+        it('updates seeding type and area options when a new crop has been selected', () => {
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .children()
+                    .first()
+                        .should('have.value', 'All')
+                    .next()
+                        .should('have.value', 'Direct Seedings')
+                    .next()
+                        .should('have.value', 'Tray Seedings')
+
+            cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
+                .children()
+                    .first()
+                        .should('have.value', 'All')
+                    .next()
+                        .should('have.value', 'A')
+                    .next()
+                        .should('have.value', 'CHUAU')
+                    .next()
+                        .should('have.value', 'CHUAU-3')
+                    .next()
+                        .should('have.value', 'SEEDING BENCH')
+
+            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
+                .select('SCALLION')
+                .should('have.value', 'SCALLION')
+
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .children()
+                    .first()
+                        .should('have.value', 'All')
+                    .next()
+                        .should('have.value', 'Tray Seedings')
+
+            cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
+                .children()
+                    .first()
+                        .should('have.value', 'All')
+                    .next()
+                        .should('have.value', 'CHUAU')
+
+            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
+                .select('All')
+                .should('have.value', 'All')
+        })
+
+        it('updates seeding type and crop options when a new area has been selected', () => {
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .children()
+                    .first()
+                        .should('have.value', 'All')
+                    .next()
+                        .should('have.value', 'Direct Seedings')
+                    .next()
+                        .should('have.value', 'Tray Seedings')
+
+            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
+                .children()
+                    .first()
+                        .should('have.value', 'All')
+                    .next()
+                        .should('have.value', 'ARUGULA')
+                    .next()
+                        .should('have.value', 'CARROT')
+                    .next()
+                        .should('have.value', 'CHARD')
+                    .next()
+                        .should('have.value', 'ONION-FRESH')
+                    .next()
+                        .should('have.value', 'SCALLION')
+
+            cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
+                .select('CHUAU')
+                .should('have.value', 'CHUAU')
+
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .children()
+                    .first()
+                        .should('have.value', 'All')
+                    .next()
+                        .should('have.value', 'Tray Seedings')
+
+            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
+                .children()
+                    .first()
+                        .should('have.value', 'All')
+                    .next()
+                        .should('have.value', 'ONION-FRESH')
+                    .next()
+                        .should('have.value', 'SCALLION')
+
+            cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
+                .select('All')
+                .should('have.value', 'All')
+        })
+
+        it('disables the filters while a row is being edited', () => {
+            cy.get('[data-cy=edit-button-r0]')
+                .click()
+
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .should('be.disabled')
+            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
+                .should('be.disabled')
+            cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
+                .should('be.disabled')
+        })
+
+        it('filters are no longer disabled when cancel button is clicked', () => {
+            cy.get('[data-cy=edit-button-r0]')
+                .click()
+            cy.get('[data-cy=cancel-button-r0]')
+                .should('exist')
+                .click()
+            
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .should('not.be.disabled')
+            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
+                .should('not.be.disabled')
+            cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
+                .should('not.be.disabled')
+        })
+
+        it('filters are no longer disabled when save button is clicked', () => {
+            cy.get('[data-cy=edit-button-r0]').last()
+                .click()
+            cy.get('[data-cy=save-button-r0]')
+                .should('exist')
+                .click()
+            
+            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
+                .should('not.be.disabled')
+            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
+                .should('not.be.disabled')
+            cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
+                .should('not.be.disabled')
+        })
+    })
+
+    context('edit and delete buttons work', () => {
+        let logID = 0
+
+        beforeEach(() => {
+            cy.wrap(getSessionToken())
+            .then(sessionToken => {
+                token = sessionToken
+                req = {
+                    url: '/log',
+                    method: 'POST',
+                    headers: {
+                        'X-Requested-With': 'XMLHttpRequest',
+                        'X-CSRF-TOKEN' : token,
+                    },
+                    body: {
+                        "name": "TEST SEEDING",
+                        "type": "farm_seeding",
+                        "timestamp": dayjs('2001-09-20').unix(),
+                        "done": "1",  //any seeding recorded is done.
+                        "notes": {
+                            "value": "This is a test log",
+                            "format": "farm_format"
+                        },
+                        "asset": [{ 
+                            "id": "1",   //Associated planting
+                            "resource": "farm_asset"
+                        }],
+                        "log_category": [{
+                            "id": "240",
+                            "resource": "taxonomy_term"
+                        }],
+                        "movement": {
+                            "area": [{
+                                "id": "233",
+                                "resource": "taxonomy_term"
+                            }]
+                        },
+                        "quantity": [
+                            {
+                                "measure": "length", 
+                                "value": "5",  //total row feet
+                                "unit": {
+                                    "id": "20", 
+                                    "resource": "taxonomy_term"
+                                },
+                                "label": "Amount planted"
+                            },
+                            {
+                                "measure": "ratio", 
+                                "value": "38",
+                                "unit": {
+                                    "id": "38",
+                                    "resource": "taxonomy_term"
+                                },
+                                "label": "Rows/Bed"
+                            },
+                            {
+                                "measure": "time", 
+                                "value": "0.5", 
+                                "unit": {
+                                    "id": "29",
+                                    "resource": "taxonomy_term"
+                                },
+                                "label": "Labor"
+                            },
+                            {
+                                "measure": "count", 
+                                "value": "1", 
+                                "unit": {
+                                    "id": "15",
+                                    "resource": "taxonomy_term"
+                                },
+                                "label": "Workers"
+                            },
+                        ],
+                        "created": dayjs().unix(),
+                        "lot_number": "N/A (No Variety)",
+                        "data": "1"
+                    }
+                }
+
+                cy.request(req).as('create')
+                cy.get('@create').should(function(response) {
+                    expect(response.status).to.equal(201)
+                    logID = response.body.id
+                })
+            })
+
+            cy.get('[data-cy=start-date-select]')
+                .should('exist')
+                .type('2001-01-25')
+            cy.get('[data-cy=end-date-select]')
+                .should('exist')
+                .type('2001-12-25')
+            cy.get('[data-cy=generate-rpt-btn]').first()
+                .click()
+        })
+
+        it('edits the database when a row is edited in the table', () => {
+            cy.get('[data-cy=edit-button-r0]')
+                .click()   
+            cy.get('[data-cy=date-input-r0c0]')
+                .type('2001-09-28')  
+            cy.get('[data-cy=dropdown-input-r0c1]')
+                .select('TOMATO')
+            cy.get('[data-cy=dropdown-input-r0c2]')
+                .select('A')
+            cy.get('[data-cy=number-input-r0c10]')
+                .type('4')
+            cy.get('[data-cy=number-input-r0c11]')
+                .type('0.25')
+
+            cy.get('[data-cy=text-input-r0c13]')
+                .type('New Comment')
+                .blur()
+
+            // Button is actionable, unfortunately it's not in view
+            cy.get('[data-cy=save-button-r0]')
+                .click({force:true})
+
+            cy.wrap(getRecord('/log.json?type=farm_seeding&id=' + logID)).as('check')
+            cy.get('@check').should(function(response) {
+                expect(response.data.list[0].name).to.equal('TEST SEEDING')
+            })
+                .then(() => {
+                    cy.wrap(deleteRecord("/log/" + logID , token)).as('seedingDelete')
+                })
+            cy.get('@seedingDelete').should((response) => {
+                expect(response.status).to.equal(200)
+            })
+        })
+
+        it('deletes a log from the database when the delete button is pressed', () => {
+            cy.get('[data-cy=delete-button-r0]')
+                .click((response) => {
+                    expect(response.status).to.equal(200)
+                })
+        })
+    })
+
+    context('make sure any APIs that fail on page load make the API failed alert appear', () => {
+        beforeEach(() => {
+            cy.login('manager1', 'farmdata2')
+            
+        })
+        
+        it('fail the session token API: outside of 2xx error code', () => {
+            cy.intercept('GET', 'restws/session/token', { statusCode: 500 }).as('failedSessionTok')
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.wait('@failedSessionTok')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        it('fail the session token API: network error', () => {
+            cy.intercept('GET', 'restws/session/token', { forceNetworkError: true }).as('failedSessionTok')
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.wait('@failedSessionTok')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        // if something else happens while setting up the request
+        // then it would also be handled here. 
+        // it('fail the session token API: something happened that triggered an error', () => {
+        // })
+
+        it('fail the crop map API: outside of 2xx error code', () => {
+            cy.intercept('GET', 'taxonomy_term?bundle=farm_crops&page=1', { statusCode: 500 }).as('failedCropMap')
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.wait('@failedCropMap')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        it('fail the crop map API: network error', () => {
+            cy.intercept('GET', 'taxonomy_term?bundle=farm_crops&page=1', { forceNetworkError: true }).as('failedCropMap')
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.wait('@failedCropMap')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        // if something else happens while setting up the request
+        // then it would also be handled here. 
+        // it('fail the crop map API: something happened that triggered an error', () => {
+        // })
+
+        it('fail the user map API: outside of 2xx error code', () => {
+            cy.intercept('GET', 'user', { statusCode: 500 }).as('failedUserMap')
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')         
+            cy.wait('@failedUserMap')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        it('fail the user map API: network error', () => {
+            cy.intercept('GET', 'user', { forceNetworkError: true }).as('failedUserMap')
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')         
+            cy.wait('@failedUserMap')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        // if something else happens while setting up the request
+        // then it would also be handled here. 
+        // it('fail the user map API: something happened that triggered an error', () => {
+        // })
+        
+        it('fail the area map API: outside of 2xx error code', () => {
+            cy.intercept('GET', 'taxonomy_term.json?bundle=farm_areas', { statusCode: 500 }).as('failedAreaMap') 
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.wait('@failedAreaMap')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        it('fail the area map API: outside of network error', () => {
+            cy.intercept('GET', 'taxonomy_term.json?bundle=farm_areas', { forceNetworkError: true }).as('failedAreaMap') 
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.wait('@failedAreaMap')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        // if something else happens while setting up the request
+        // then it would also be handled here. 
+        // it('fail the area map API: something happened that triggered an error', () => {
+        // })
+
+        it('fail the unit map API: outside of 2xx error code', () => {
+            cy.intercept('GET', 'taxonomy_term.json?bundle=farm_quantity_units', { statusCode: 500 }).as('failedUnitMap')
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.wait('@failedUnitMap')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        it('fail the unit map API: network error', () => {
+            cy.intercept('GET', 'taxonomy_term.json?bundle=farm_quantity_units', { forceNetworkError: true }).as('failedUnitMap')
+
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+            cy.wait('@failedUnitMap')
+                .then(() => {
+                    cy.get('[data-cy=alert-err-handler]')
+                    .should('be.visible')
+                    cy.window().its('scrollY').should('equal', 0)
+                    cy.get('[data-cy=alert-err-handler]')
+                    .click()
+                    .should('not.visible')
+                }) 
+        })
+
+        // if something else happens while setting up the request
+        // then it would also be handled here. 
+        // it('fail the unit map API: something happened that triggered an error', () => {
+        // })
+    })
+
+    context('Configuration tests', () => {
+        before(() =>{
+            cy.login('manager1', 'farmdata2')
+            .then(() => {
+                cy.wrap(getConfiguration()).as('def')
+                cy.wrap(getSessionToken()).as('token')
+            }) 
+            cy.get('@token').should(function(token) {
+                sessionToken = token
+            })
+            cy.get('@def').should(function(map) {
+                configMap = map.data
+                defaultConfig = configMap
+            })
+        })
+
+        beforeEach(() => {
+            cy.login('manager1', 'farmdata2')
+            .then(() => {
+                cy.wrap(getSessionToken()).as('token')
+            })
+            cy.get('@token').should(function(token) {
+                sessionToken = token
+            })
+            .then(() => {
+                cy.wrap(setConfiguration(testConfig, sessionToken)).as('updateConfig')
+            })
+            cy.get('@updateConfig') 
+            .then(() => {
+                cy.wrap(getConfiguration()).as('getNewConfigMap')
+            })          
+            // set up intercept for setting up the configuration
+            cy.get('@getNewConfigMap').should(function(map) {
+                configMap = map.data
+            })
+            
+            // Setting up wait for the request in the created() to complete.
+            cy.intercept('GET', 'taxonomy_term?bundle=farm_crops&page=1').as('cropmap')
+            cy.intercept('GET', 'restws/session/token').as('sessiontok')
+            cy.intercept('GET', 'user').as('usermap')
+            cy.intercept('GET', 'taxonomy_term.json?bundle=farm_areas').as('areamap')        
+            cy.intercept('GET', 'taxonomy_term.json?bundle=farm_quantity_units').as('unitmap')
+            cy.intercept('GET', 'taxonomy_term.json?bundle=farm_log_categories').as('logtypemap')            
+            cy.intercept('GET', '/fd2_config/1').as('getConfigMap')       
+            
+            cy.visit('/farm/fd2-barn-kit/seedingReport')
+
+            cy.wait(['@cropmap', '@areamap', '@cropmap', '@usermap', '@areamap', '@unitmap',])
+        })
+
+        afterEach(() => {
+            cy.wrap(setConfiguration(defaultConfig, sessionToken)).as('resetConfig')
+            cy.get('@resetConfig')
+        })
+
+        it('test labor required', () => {
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+            cy.get('[data-cy=generate-rpt-btn]')
+                .click()
+            cy.get('[data-cy=h0]')
+                .should('have.text', 'Date')
+            cy.get('[data-cy=h1]')
+                .should('have.text', 'Crop')
+            cy.get('[data-cy=h2]')
+                .should('have.text', 'Area')
+            cy.get('[data-cy=h3]')
+                .should('have.text', 'Seeding')
+            cy.get('[data-cy=h4]')
+                .should('not.exist')
+            cy.get('[data-cy=h5]')
+                .should('not.exist')
+            cy.get('[data-cy=h6]')
+                .should('not.exist')
+            cy.get('[data-cy=h7]')
+                .should('not.exist')
+            cy.get('[data-cy=h8]')
+                .should('not.exist')
+            cy.get('[data-cy=h9]')
+                .should('not.exist')
+            cy.get('[data-cy=h10]')
+                .should('have.text', 'Workers')
+            cy.get('[data-cy=h11]')
+                .should('have.text', 'Hours')
+            cy.get('[data-cy=h12]')
+                .should('have.text', 'Varieties')
+            cy.get('[data-cy=h13]')
+                .should('have.text', 'Comments')
+            cy.get('[data-cy=h14]')
+                .should('have.text', 'User')
+            cy.get('[data-cy=edit-header]')
+                .should('have.text', 'Edit')
+            cy.get('[data-cy=delete-header]')
+                .should('have.text', 'Delete')
+        })
+
+        it('test labor optional', () => {
+            OptionalConfig = {id: 1, labor: 'Optional'}
+            cy.wrap(setConfiguration(OptionalConfig, sessionToken)).as('updateConfig')
+            cy.get('@updateConfig')
+            .then(() => {
+                cy.reload()
+            })
+            
+            // Setting up wait for the request in the created() to complete.
+            cy.intercept('GET', 'restws/session/token').as('sessiontok')
+            cy.intercept('GET', 'user').as('usermap')
+            cy.intercept('GET', 'taxonomy_term.json?bundle=farm_quantity_units').as('unitmap')
+            cy.intercept('GET', 'taxonomy_term.json?bundle=farm_log_categories').as('logtypemap')
+
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+            cy.get('[data-cy=generate-rpt-btn]')
+                .click()
+            cy.get('[data-cy=h0]')
+                .should('have.text', 'Date')
+            cy.get('[data-cy=h1]')
+                .should('have.text', 'Crop')
+            cy.get('[data-cy=h2]')
+                .should('have.text', 'Area')
+            cy.get('[data-cy=h3]')
+                .should('have.text', 'Seeding')
+            cy.get('[data-cy=h4]')
+                .should('not.exist')
+            cy.get('[data-cy=h5]')
+                .should('not.exist')
+            cy.get('[data-cy=h6]')
+                .should('not.exist')
+            cy.get('[data-cy=h7]')
+                .should('not.exist')
+            cy.get('[data-cy=h8]')
+                .should('not.exist')
+            cy.get('[data-cy=h9]')
+                .should('not.exist')
+            cy.get('[data-cy=h10]')
+                .should('have.text', 'Workers')
+            cy.get('[data-cy=h11]')
+                .should('have.text', 'Hours')
+            cy.get('[data-cy=h12]')
+                .should('have.text', 'Varieties')
+            cy.get('[data-cy=h13]')
+                .should('have.text', 'Comments')
+            cy.get('[data-cy=h14]')
+                .should('have.text', 'User')
+            cy.get('[data-cy=edit-header]')
+                .should('have.text', 'Edit')
+            cy.get('[data-cy=delete-header]')
+                .should('have.text', 'Delete')
+        })
+
+        it('test labor hidden', () => {
+            hiddenConfig = {id: 1, labor: 'Hidden'}
+            cy.wrap(setConfiguration(hiddenConfig, sessionToken)).as('updateConfig')
+            cy.get('@updateConfig')
+            .then(() => {
+                cy.reload()
+            })
+            
+            // Setting up wait for the request in the created() to complete.
+            cy.intercept('GET', 'restws/session/token').as('sessiontok')
+            cy.intercept('GET', 'user').as('usermap')
+            cy.intercept('GET', 'taxonomy_term.json?bundle=farm_quantity_units').as('unitmap')
+            cy.intercept('GET', 'taxonomy_term.json?bundle=farm_log_categories').as('logtypemap')
+
+            cy.get('[data-cy=start-date-select]')
+                .type('2019-01-01')
+            cy.get('[data-cy=end-date-select]')
+                .type('2019-03-01')
+            cy.get('[data-cy=generate-rpt-btn]')
+                .click()
+            cy.get('[data-cy=h0]')
+                .should('have.text', 'Date')
+            cy.get('[data-cy=h1]')
+                .should('have.text', 'Crop')
+            cy.get('[data-cy=h2]')
+                .should('have.text', 'Area')
+            cy.get('[data-cy=h3]')
+                .should('have.text', 'Seeding')
+            cy.get('[data-cy=h4]')
+                .should('not.exist')
+            cy.get('[data-cy=h5]')
+                .should('not.exist')
+            cy.get('[data-cy=h6]')
+                .should('not.exist')
+            cy.get('[data-cy=h7]')
+                .should('not.exist')
+            cy.get('[data-cy=h8]')
+                .should('not.exist')
+            cy.get('[data-cy=h9]')
+                .should('not.exist')
+            cy.get('[data-cy=h10]')
+                .should('not.exist')
+            cy.get('[data-cy=h11]')
+                .should('not.exist')
+            cy.get('[data-cy=h12]')
+                .should('have.text', 'Varieties')
+            cy.get('[data-cy=h13]')
+                .should('have.text', 'Comments')
+            cy.get('[data-cy=h14]')
+                .should('have.text', 'User')
+            cy.get('[data-cy=edit-header]')
+                .should('have.text', 'Edit')
+            cy.get('[data-cy=delete-header]')
+                .should('have.text', 'Delete')
+        })
+    })
+})

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.spec.js
@@ -12,7 +12,7 @@ var deleteRecord = FarmOSAPI.deleteRecord
 var getConfiguration = FarmOSAPI.getConfiguration
 var setConfiguration = FarmOSAPI.setConfiguration
 
-describe('Testing for the seeding report page', () => {
+describe('Testing for the transplanting report page', () => {
     let cropToIDMap = null
     let IDToCropMap = null
     let areaToIDMap = null
@@ -56,7 +56,7 @@ describe('Testing for the seeding report page', () => {
         cy.intercept('GET', 'taxonomy_term.json?bundle=farm_quantity_units').as('unitMap') 
         
         // cy.restoreLocalStorage()
-        cy.visit('/farm/fd2-barn-kit/seedingReport')
+        cy.visit('/farm/fd2-barn-kit/transplantingReport')
     
         // Wait here for the maps to load in the page.   
         cy.wait(['@cropmap', '@areamap', '@IDCropMap', '@userMap', '@unitMap'])
@@ -97,10 +97,7 @@ describe('Testing for the seeding report page', () => {
             cy.get('[data-cy=report-table]')
                 .should('exist')
 
-            cy.get('[data-cy=direct-summary]')
-                .should('exist')
-
-            cy.get('[data-cy=tray-summary]')
+            cy.get('[data-cy=transplanting-summary]')
                 .should('exist')
         })
 
@@ -114,7 +111,7 @@ describe('Testing for the seeding report page', () => {
                 .should('exist')
                 .type('2019-03-01')
 
-            cy.intercept('GET', '/log.json?type=farm_seeding&timestamp[ge]=1546300800&timestamp[le]=1551398400', { statusCode: 500 })
+            cy.intercept('GET', '/log.json?type=farm_transplanting&timestamp[ge]=1546300800&timestamp[le]=1551398400', { statusCode: 500 })
             .as('getAPIFailure')
             cy.get('[data-cy=generate-rpt-btn]')
                 .click()
@@ -133,10 +130,7 @@ describe('Testing for the seeding report page', () => {
             cy.get('[data-cy=report-table]')
                 .should('not.exist')
 
-            cy.get('[data-cy=direct-summary]')
-                .should('not.exist')
-
-            cy.get('[data-cy=tray-summary]')
+                cy.get('[data-cy=transplanting-summary]')
                 .should('not.exist')
         }) 
 
@@ -150,7 +144,7 @@ describe('Testing for the seeding report page', () => {
                 .should('exist')
                 .type('2019-03-01')
 
-            cy.intercept('GET', '/log.json?type=farm_seeding&timestamp[ge]=1546300800&timestamp[le]=1551398400', { forceNetworkError: true })
+            cy.intercept('GET', '/log.json?type=farm_transplanting&timestamp[ge]=1546300800&timestamp[le]=1551398400', { forceNetworkError: true })
             .as('getAPIFailure')
             cy.get('[data-cy=generate-rpt-btn]')
                 .click()
@@ -169,46 +163,18 @@ describe('Testing for the seeding report page', () => {
             cy.get('[data-cy=report-table]')
                 .should('not.exist')
 
-            cy.get('[data-cy=direct-summary]')
-                .should('not.exist')
-
-            cy.get('[data-cy=tray-summary]')
+            cy.get('[data-cy=transplanting-summary]')
                 .should('not.exist')
         }) 
     })
 
-    context('assures filters are actually populated', () => {
-
-        it('test if seeding type are correctly loaded to the filter dropdown', () => {
-            cy.get('[data-cy=start-date-select]')
-                .type('2019-01-01')
-            cy.get('[data-cy=end-date-select]')
-                .type('2019-03-01')
-            cy.get('[data-cy=generate-rpt-btn]').click()
-
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .children() 
-                .first()
-                .should('have.value', 'All')
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .children() 
-                .first()  
-                .next()
-                .should('have.value', 'Direct Seedings')
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .children() 
-                .last()
-                .should('have.value', 'Tray Seedings')
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .children() 
-                .should('have.length', '3')
-        })
+    context.only('assures filters are actually populated', () => {
 
         it('test if crops are correctly loaded to the filter dropdown', () => {
             cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')
             cy.get('[data-cy=end-date-select]')
-                .type('2019-03-01')
+                .type('2019-05-01')
             cy.get('[data-cy=generate-rpt-btn]').click()
 
             cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
@@ -219,21 +185,21 @@ describe('Testing for the seeding report page', () => {
                 .children() 
                 .first()  
                 .next()
-                .should('have.value', 'ARUGULA')
+                .should('have.value', 'BOKCHOY')
             cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
                 .children() 
                 .last()
                 .should('have.value', 'SCALLION')
             cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
                 .children() 
-                .should('have.length', '22')
+                .should('have.length', '19')
         })
 
         it('test if areas are correctly loaded to the filter dropdown', () => {
             cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')
             cy.get('[data-cy=end-date-select]')
-                .type('2019-03-01')
+                .type('2019-05-01')
             cy.get('[data-cy=generate-rpt-btn]').click()
 
             cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
@@ -244,14 +210,14 @@ describe('Testing for the seeding report page', () => {
                 .children() 
                 .first()  
                 .next()
-                .should('have.value', 'A')
+                .should('have.value', 'CHUAU-2')
             cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
                 .children() 
                 .last()
-                .should('have.value', 'SEEDING BENCH')
+                .should('have.value', 'T')
             cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
                 .children() 
-                .should('have.length', '12')
+                .should('have.length', '8')
         })
     })
 
@@ -261,7 +227,7 @@ describe('Testing for the seeding report page', () => {
             cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')
             cy.get('[data-cy=end-date-select]')
-                .type('2019-03-01')
+                .type('2019-08-01')
             cy.get('[data-cy=generate-rpt-btn]').click()
             cy.get('[data-cy=loader]').should('be.visible')
         })
@@ -270,10 +236,10 @@ describe('Testing for the seeding report page', () => {
             cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')
             cy.get('[data-cy=end-date-select]')
-                .type('2019-02-01')
+                .type('2019-05-01')
             cy.get('[data-cy=generate-rpt-btn]').click()
             cy.get('[data-cy=report-table]').find('tr').its('length').then(length =>{
-                expect(length).to.equal(3)
+                expect(length).to.equal(30)
                 cy.get('[data-cy=loader]').should('not.exist')
             }) 
         })
@@ -282,7 +248,7 @@ describe('Testing for the seeding report page', () => {
             cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')
             cy.get('[data-cy=end-date-select]')
-                .type('2019-03-03')
+                .type('2019-08-03')
             cy.get('[data-cy=generate-rpt-btn]').click()
             cy.get('[data-cy=loader]').should('be.visible')
         })
@@ -290,11 +256,10 @@ describe('Testing for the seeding report page', () => {
 
     context('clicking on date ranges hides report', () => {
         beforeEach(() => {
-            //cy.visit('/farm/fd2-barn-kit/seedingReport')
             cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')
             cy.get('[data-cy=end-date-select]')
-                .type('2019-03-01')
+                .type('2019-05-01')
             cy.get('[data-cy=generate-rpt-btn]')
                 .click()
         })
@@ -338,7 +303,7 @@ describe('Testing for the seeding report page', () => {
             cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')
             cy.get('[data-cy=end-date-select]')
-                .type('2019-03-01')
+                .type('2019-05-01')
             cy.get('[data-cy=generate-rpt-btn]').click()
             cy.get('[data-cy=no-logs-message]').should('not.exist')
         })
@@ -353,54 +318,24 @@ describe('Testing for the seeding report page', () => {
         })
     })
 
-    context('can see summary tables at appropriate times and displays appropriate message', () => {
+    context('can see the summary table at appropriate times and displays appropriate message', () => {
         beforeEach(() => {
             cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')
             cy.get('[data-cy=end-date-select]')
-                .type('2019-03-01')
+                .type('2019-05-01')
             cy.get('[data-cy=generate-rpt-btn]')
                 .click()
         })
 
         it('does not immediately display summary tables', () => {
-            cy.get('[data-cy=tray-summary]').should('not.exist')
-            cy.get('[data-cy=direct-summary]').should('not.exist')
+            cy.get('[data-cy=transplanting-summary]').should('not.exist')
         })
 
         it('shows summary tables after table is fully loaded', () => {
             cy.get('[data-cy=report-table]')
-            cy.get('[data-cy=tray-summary]',).should('be.visible')
-            cy.get('[data-cy=direct-summary]').should('be.visible')
+            cy.get('[data-cy=transplanting-summary]').should('be.visible')
         }) 
-
-        it('show tray seeding message when only direct seeding', () => {
-            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
-                .select('CARROT')
-            cy.get('[data-cy=tray-no-logs')
-                .should('have.text', 'There are no Tray Seeding logs with these parameters')
-        })
-
-        it('show direct seeding message when only tray seeding', () => {
-            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
-                .select('BOKCHOY')
-            cy.get('[data-cy=direct-no-logs')
-                .should('have.text', 'There are no Direct Seeding logs with these parameters')
-            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
-                .select('All')
-        })
-
-        it('show one summary table with specific seeding type', () => {
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-            .select('Direct Seedings')
-            cy.get('[data-cy=direct-summary').should('exist')
-            cy.get('[data-cy=tray-summary]').should('not.exist')
-
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-            .select('Tray Seedings')
-            cy.get('[data-cy=direct-summary').should('not.exist')
-            cy.get('[data-cy=tray-summary]').should('exist')
-        })
     })
 
     context('displays the right information in the table', () => {
@@ -408,22 +343,22 @@ describe('Testing for the seeding report page', () => {
             cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')
             cy.get('[data-cy=end-date-select]')
-                .type('2019-03-01')
+                .type('2019-05-01')
             cy.get('[data-cy=generate-rpt-btn]')
                 .click()
 
             cy.get('[data-cy=report-table]').find('tr').its('length')
                 .then(length =>{
-                    expect(length).to.equal(35)
+                    expect(length).to.equal(30)
                 })
         })
 
         it('requests and displays logs that fall between the specified dates', () => {
             let currentTimestamp = null
             const startTimestamp = dayjs('2019-01-01').unix()
-            const endTimestamp = dayjs('2019-03-01').unix()
+            const endTimestamp = dayjs('2019-05-01').unix()
 
-            for(let r = 0; r < 34; r++){
+            for(let r = 0; r < 28; r++){
                 cy.get('[data-cy=r' + r + 'c0')
                     .invoke('text')
                     .then(dateText => {
@@ -433,52 +368,19 @@ describe('Testing for the seeding report page', () => {
             }
         })
 
-        it('filters by type of seeding', () => {
-            let typeSeeding = null
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .select('Direct Seedings')
-                .should('have.value', 'Direct Seedings')
-
-            for(let r = 0; r < 7; r++){
-                cy.get('[data-cy=r' + r + 'c3')
-                    .invoke('text')
-                    .then(seeding => {
-                        typeSeeding = seeding
-                        expect(typeSeeding, 'Direct')
-                    })
-            }
-
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .select('Tray Seedings')
-                .should('have.value', 'Tray Seedings')
-
-            for(let r = 0; r < 27; r++){
-                cy.get('[data-cy=r' + r + 'c3')
-                    .invoke('text')
-                    .then(seeding => {
-                        typeSeeding = seeding
-                        expect(typeSeeding, 'Tray')
-                    })
-            }
-
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .select('All')
-                .should('have.value', 'All')
-        })
-
         it('filters by crop', () => {
             let crop = null
             cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
-                .select('LEEK')
-                .should('have.value', 'LEEK')
+                .select('BROCCOLI')
+                .should('have.value', 'BROCCOLI')
 
 
-            for(let r = 0; r < 3; r++){
+            for(let r = 0; r < 2; r++){
                 cy.get('[data-cy=r' + r + 'c1')
                     .invoke('text')
                     .then(actualCrop => {
                         crop = actualCrop
-                        expect(crop, 'LEEK')
+                        expect(crop, 'BROCCOLI')
                     })
             }
 
@@ -490,15 +392,15 @@ describe('Testing for the seeding report page', () => {
         it('filters by field', () => {
             let area = null
             cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
-                .select('CHUAU')
-                .should('have.value', 'CHUAU')
+                .select('CHUAU-4')
+                .should('have.value', 'CHUAU-4')
 
-            for(let r = 0; r < 8; r++){
+            for(let r = 0; r < 4; r++){
                 cy.get('[data-cy=r' + r + 'c2')
                     .invoke('text')
                     .then(actualArea => {
                         area = actualArea
-                        expect(area, 'CHUAU')
+                        expect(area, 'CHUAU-4')
                     })
             }
             
@@ -508,61 +410,48 @@ describe('Testing for the seeding report page', () => {
             })
         })
 
-    context('has the correct totals in the seeding summary tables', () => {
+    context('has the correct totals in the transplanting summary tables', () => {
         beforeEach(() => {
             cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')
             cy.get('[data-cy=end-date-select]')
-                .type('2019-03-01')
+                .type('2019-05-01')
             cy.get('[data-cy=generate-rpt-btn]')
                 .click()
         })
 
-        it('verify all values in the direct seeding summary', () => {
-            cy.get('[data-cy=direct-total-rowft]')
-            .should('have.text', '26177')
-
-            cy.get('[data-cy=direct-total-bedft]')
-            .should('have.text', '8803')
-
-            cy.get('[data-cy=direct-total-hours]')
-            .should('have.text', '7')
-
-            cy.get('[data-cy=direct-total-rowft-hour]')
-            .should('have.text', '3739.57')
-
-            cy.get('[data-cy=direct-total-bedfr-hour]')
-            .should('have.text', '1257.57')
-            })
-
-        it('verify all values in the tray seeding summary', () => {
-            cy.get('[data-cy=tray-total-seeds]')
-            .should('have.text', '16808')
+        it('verify all values in the transplanting seeding summary', () => {
+            cy.get('[data-cy=transplant-total-rowft]')
+            .should('have.text', '9674')
     
-            cy.get('[data-cy=tray-total-trays]')
-            .should('have.text', '212.5')
+            cy.get('[data-cy=transplant-total-bedft]')
+            .should('have.text', '3778')
     
-            cy.get('[data-cy=tray-total-seeds-hour]')
-            .should('have.text', '20.1')
+            cy.get('[data-cy=transplant-total-numTrays]')
+            .should('have.text', '92')
     
-            cy.get('[data-cy=tray-avg-seeds-hour]')
-            .should('have.text', '836.22')
+            cy.get('[data-cy=transplant-total-hours]')
+            .should('have.text', '29')
+
+            cy.get('[data-cy=transplant-total-rowft-hour]')
+            .should('have.text', '333.59')
+
+            cy.get('[data-cy=transplant-total-bedfr-hour]')
+            .should('have.text', '130.28')
         })
     })
 
-    context('changing the type of seeding changes the visible columns', () => {
+    context('displays only relevant columns under certain conditions', () => {
         beforeEach(() => {
             cy.get('[data-cy=start-date-select]')
                 .type('2019-01-01')
             cy.get('[data-cy=end-date-select]')
-                .type('2019-03-01')
+                .type('2019-05-01')
             cy.get('[data-cy=generate-rpt-btn]')
                 .click()
         })
 
-        it('displays only columns relevant to both seedings when "All" is selected', () => {
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .should('have.value', 'All')
+        it('displays only relevant columns', () => {
             cy.get('[data-cy=h0]')
                 .should('have.text', 'Date')
             cy.get('[data-cy=h1]')
@@ -570,84 +459,29 @@ describe('Testing for the seeding report page', () => {
             cy.get('[data-cy=h2]')
                 .should('have.text', 'Area')
             cy.get('[data-cy=h3]')
-                .should('have.text', 'Seeding')
-            cy.get('[data-cy=h4]')
-                .should('not.exist')
-            cy.get('[data-cy=h5]')
-                .should('not.exist')
-            cy.get('[data-cy=h6]')
-                .should('not.exist')
-            cy.get('[data-cy=h7]')
-                .should('not.exist')
-            cy.get('[data-cy=h8]')
-                .should('not.exist')
-            cy.get('[data-cy=h9]')
-                .should('not.exist')
-            cy.get('[data-cy=h10]')
-                .should('have.text', 'Workers')
-            cy.get('[data-cy=h11]')
-                .should('have.text', 'Hours')
-            cy.get('[data-cy=h12]')
-                .should('have.text', 'Varieties')
-            cy.get('[data-cy=h13]')
-                .should('have.text', 'Comments')
-            cy.get('[data-cy=h14]')
-                .should('have.text', 'User')
-            cy.get('[data-cy=edit-header]')
-                .should('have.text', 'Edit')
-            cy.get('[data-cy=delete-header]')
-                .should('have.text', 'Delete')
-        })
-
-        it('displays columns relevant to direct seedings when "Direct Seedings" is selected', () => {
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .select('Direct Seedings')
-                .should('have.value', 'Direct Seedings')
-            cy.get('[data-cy=h0]')
-                .should('have.text', 'Date')
-            cy.get('[data-cy=h1]')
-                .should('have.text', 'Crop')
-            cy.get('[data-cy=h2]')
-                .should('have.text', 'Area')
-            cy.get('[data-cy=h3]')
-                .should('have.text', 'Seeding')
+                .should('have.text', 'Bed Feet')
             cy.get('[data-cy=h4]')
                 .should('have.text', 'Row Feet')
             cy.get('[data-cy=h5]')
-                .should('have.text', 'Bed Feet')
-            cy.get('[data-cy=h6]')
                 .should('have.text', 'Rows/Bed')
+            cy.get('[data-cy=h6]')
+                .should('have.text', 'Trays')
             cy.get('[data-cy=h7]')
-                .should('not.exist')
-            cy.get('[data-cy=h8]')
-                .should('not.exist')
-            cy.get('[data-cy=h9]')
-                .should('not.exist')
-            cy.get('[data-cy=h10]')
                 .should('have.text', 'Workers')
-            cy.get('[data-cy=h11]')
+            cy.get('[data-cy=h8]')
                 .should('have.text', 'Hours')
-            cy.get('[data-cy=h12]')
-                .should('have.text', 'Varieties')
-            cy.get('[data-cy=h13]')
+            cy.get('[data-cy=h9]')
                 .should('have.text', 'Comments')
-            cy.get('[data-cy=h14]')
+            cy.get('[data-cy=h10]')
                 .should('have.text', 'User')
             cy.get('[data-cy=edit-header]')
                 .should('have.text', 'Edit')
             cy.get('[data-cy=delete-header]')
                 .should('have.text', 'Delete')
-            cy.get('[data-cy=save-header]')
-                .should('not.exist')
-            cy.get('[data-cy=cancel-header]')
-                .should('not.exist')
         })
 
-        it('displays columns relevant to direct seedings when "Direct Seedings" is selected and in edit mode', () => {
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .select('Direct Seedings')
-                .should('have.value', 'Direct Seedings')
-            cy.get('[data-cy=edit-button-r0]').first()
+        it('displays only relevant columns when in edit mode', () => {
+            cy.get('[data-cy=edit-button-r0]')
                 .click()
             cy.get('[data-cy=h0]')
                 .should('have.text', 'Date')
@@ -656,28 +490,20 @@ describe('Testing for the seeding report page', () => {
             cy.get('[data-cy=h2]')
                 .should('have.text', 'Area')
             cy.get('[data-cy=h3]')
-                .should('have.text', 'Seeding')
+                .should('have.text', 'Bed Feet')
             cy.get('[data-cy=h4]')
                 .should('have.text', 'Row Feet')
             cy.get('[data-cy=h5]')
-                .should('have.text', 'Bed Feet')
-            cy.get('[data-cy=h6]')
                 .should('have.text', 'Rows/Bed')
+            cy.get('[data-cy=h6]')
+                .should('have.text', 'Trays')
             cy.get('[data-cy=h7]')
-                .should('not.exist')
-            cy.get('[data-cy=h8]')
-                .should('not.exist')
-            cy.get('[data-cy=h9]')
-                .should('not.exist')
-            cy.get('[data-cy=h10]')
                 .should('have.text', 'Workers')
-            cy.get('[data-cy=h11]')
+            cy.get('[data-cy=h8]')
                 .should('have.text', 'Hours')
-            cy.get('[data-cy=h12]')
-                .should('have.text', 'Varieties')
-            cy.get('[data-cy=h13]')
+            cy.get('[data-cy=h9]')
                 .should('have.text', 'Comments')
-            cy.get('[data-cy=h14]')
+            cy.get('[data-cy=h10]')
                 .should('have.text', 'User')
             cy.get('[data-cy=edit-header]')
                 .should('not.exist')
@@ -685,98 +511,6 @@ describe('Testing for the seeding report page', () => {
                 .should('not.exist')
             cy.get('[data-cy=save-header]')
                 .should('have.text', 'Save')
-            cy.get('[data-cy=cancel-header]')
-                .should('have.text', 'Cancel')
-
-            //Force the action to occur because in the viewport isn't big enough for the 
-            //button to be clickable
-            cy.get('[data-cy=cancel-button-r0]')
-                .click({force:true})
-        })
-
-        it('displays columns relevant to tray seedings when "Tray Seedings" is selected', () => {
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .select('Tray Seedings')
-                .should('have.value', 'Tray Seedings')
-                cy.get('[data-cy=h1]')
-                .should('have.text', 'Crop')
-            cy.get('[data-cy=h2]')
-                .should('have.text', 'Area')
-            cy.get('[data-cy=h3]')
-                .should('have.text', 'Seeding')
-            cy.get('[data-cy=h4]')
-                .should('not.exist')
-            cy.get('[data-cy=h5]')
-                .should('not.exist')
-            cy.get('[data-cy=h6]')
-                .should('not.exist')
-            cy.get('[data-cy=h7]')
-                .should('have.text', 'Seeds')
-            cy.get('[data-cy=h8]')
-                .should('have.text', 'Trays')
-            cy.get('[data-cy=h9]')
-                .should('have.text', 'Cells/Tray')
-            cy.get('[data-cy=h10]')
-                .should('have.text', 'Workers')
-            cy.get('[data-cy=h11]')
-                .should('have.text', 'Hours')
-            cy.get('[data-cy=h12]')
-                .should('have.text', 'Varieties')
-            cy.get('[data-cy=h13]')
-                .should('have.text', 'Comments')
-            cy.get('[data-cy=h14]')
-                .should('have.text', 'User')
-            cy.get('[data-cy=edit-header]')
-                .should('have.text', 'Edit')
-            cy.get('[data-cy=delete-header]')
-                .should('have.text', 'Delete')
-            cy.get('[data-cy=save-header]')
-                .should('not.exist')
-            cy.get('[data-cy=cancel-header]')
-                .should('not.exist')
-        })
-
-        it('displays columns relevant to tray seedings when "Tray Seedings" is selected and in edit mode', () => {
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .select('Tray Seedings')
-                .should('have.value', 'Tray Seedings')
-            cy.get('[data-cy=edit-button-r0]').first()
-                .click()
-            cy.get('[data-cy=h1]')
-                .should('have.text', 'Crop')
-            cy.get('[data-cy=h2]')
-                .should('have.text', 'Area')
-            cy.get('[data-cy=h3]')
-                .should('have.text', 'Seeding')
-            cy.get('[data-cy=h4]')
-                .should('not.exist')
-            cy.get('[data-cy=h5]')
-                .should('not.exist')
-            cy.get('[data-cy=h6]')
-                .should('not.exist')
-            cy.get('[data-cy=h7]')
-                .should('have.text', 'Seeds')
-            cy.get('[data-cy=h8]')
-                .should('have.text', 'Trays')
-            cy.get('[data-cy=h9]')
-                .should('have.text', 'Cells/Tray')
-            cy.get('[data-cy=h10]')
-                .should('have.text', 'Workers')
-            cy.get('[data-cy=h11]')
-                .should('have.text', 'Hours')
-            cy.get('[data-cy=h12]')
-                .should('have.text', 'Varieties')
-            cy.get('[data-cy=h13]')
-                .should('have.text', 'Comments')
-            cy.get('[data-cy=h14]')
-                .should('have.text', 'User')
-            cy.get('[data-cy=edit-header]')
-                .should('not.exist')
-            cy.get('[data-cy=delete-header]')
-                .should('not.exist')
-            cy.get('[data-cy=save-header]')
-                .should('have.text', 'Save')
-
             cy.get('[data-cy=cancel-header]')
                 .should('have.text', 'Cancel')
 
@@ -790,162 +524,77 @@ describe('Testing for the seeding report page', () => {
     context('date picker and filter behavior', () => {
         beforeEach(() => {
             cy.get('[data-cy=start-date-select]')
-                .type('2019-02-13')
+                .type('2019-01-01')
             cy.get('[data-cy=end-date-select]')
-                .type('2019-02-16')
+                .type('2019-04-01')
             cy.get('[data-cy=generate-rpt-btn]')
                 .click()
         })
 
-        it('updates crop and area options when a new seeding type has been selected', () => {
-            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
-                .children()
-                    .first()
-                        .should('have.value', 'All')
-                    .next()
-                        .should('have.value', 'ARUGULA')
-                    .next()
-                        .should('have.value', 'CARROT')
-                    .next()
-                        .should('have.value', 'CHARD')
-                    .next()
-                        .should('have.value', 'ONION-FRESH')
-                    .next()
-                        .should('have.value', 'SCALLION')
-
+        it('updates area options when a new crop has been selected', () => {
             cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
                 .children()
                     .first()
                         .should('have.value', 'All')
                     .next()
-                        .should('have.value', 'A')
+                        .should('have.value', 'CHUAU-2')
                     .next()
-                        .should('have.value', 'CHUAU')
+                        .should('have.value', 'CHUAU-4')
                     .next()
-                        .should('have.value', 'CHUAU-3')
-                    .next()
-                        .should('have.value', 'SEEDING BENCH')
-
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .select('Tray Seedings')
-                .should('have.value', 'Tray Seedings')
-
-            cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
-                .children()
-                    .first()
-                        .should('have.value', 'All')
-                    .next()
-                        .should('have.value', 'CHARD')
-                    .next()
-                        .should('have.value', 'ONION-FRESH')
-                    .next()
-                        .should('have.value', 'SCALLION')
-
-            cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
-                .children()
-                    .first()
-                        .should('have.value', 'All')
-                    .next()
-                        .should('have.value', 'CHUAU')
-                    .next()
-                        .should('have.value', 'SEEDING BENCH')
-
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .select('All')
-                .should('have.value', 'All')
-
-        })
-
-        it('updates seeding type and area options when a new crop has been selected', () => {
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .children()
-                    .first()
-                        .should('have.value', 'All')
-                    .next()
-                        .should('have.value', 'Direct Seedings')
-                    .next()
-                        .should('have.value', 'Tray Seedings')
-
-            cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
-                .children()
-                    .first()
-                        .should('have.value', 'All')
-                    .next()
-                        .should('have.value', 'A')
-                    .next()
-                        .should('have.value', 'CHUAU')
-                    .next()
-                        .should('have.value', 'CHUAU-3')
-                    .next()
-                        .should('have.value', 'SEEDING BENCH')
+                        .should('have.value', 'JASMINE-1')
 
             cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
                 .select('SCALLION')
                 .should('have.value', 'SCALLION')
 
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .children()
-                    .first()
-                        .should('have.value', 'All')
-                    .next()
-                        .should('have.value', 'Tray Seedings')
-
             cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
                 .children()
                     .first()
                         .should('have.value', 'All')
                     .next()
-                        .should('have.value', 'CHUAU')
+                        .should('have.value', 'CHUAU-2')
 
             cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
                 .select('All')
                 .should('have.value', 'All')
         })
 
-        it('updates seeding type and crop options when a new area has been selected', () => {
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .children()
-                    .first()
-                        .should('have.value', 'All')
-                    .next()
-                        .should('have.value', 'Direct Seedings')
-                    .next()
-                        .should('have.value', 'Tray Seedings')
-
+        it('updates crop options when a new area has been selected', () => {
             cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
                 .children()
                     .first()
                         .should('have.value', 'All')
                     .next()
-                        .should('have.value', 'ARUGULA')
-                    .next()
-                        .should('have.value', 'CARROT')
-                    .next()
                         .should('have.value', 'CHARD')
                     .next()
-                        .should('have.value', 'ONION-FRESH')
+                        .should('have.value', 'COLLARDS')
+                    .next()
+                        .should('have.value', 'KALE')
+                    .next()
+                        .should('have.value', 'LETTUCE-GREEN')
+                    .next()
+                        .should('have.value', 'LETTUCE-RED')
+                    .next()
+                        .should('have.value', 'LETTUCE-ROMAINE')
                     .next()
                         .should('have.value', 'SCALLION')
 
             cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
-                .select('CHUAU')
-                .should('have.value', 'CHUAU')
-
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .children()
-                    .first()
-                        .should('have.value', 'All')
-                    .next()
-                        .should('have.value', 'Tray Seedings')
+                .select('CHUAU-4')
+                .should('have.value', 'CHUAU-4')
 
             cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
                 .children()
                     .first()
                         .should('have.value', 'All')
                     .next()
-                        .should('have.value', 'ONION-FRESH')
+                        .should('have.value', 'CHARD')
                     .next()
-                        .should('have.value', 'SCALLION')
+                        .should('have.value', 'COLLARDS')
+                    .next()
+                        .should('have.value', 'KALE')
+                    .next()
+                        .should('have.value', 'LETTUCE-RED')
 
             cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
                 .select('All')
@@ -956,8 +605,6 @@ describe('Testing for the seeding report page', () => {
             cy.get('[data-cy=edit-button-r0]')
                 .click()
 
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .should('be.disabled')
             cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
                 .should('be.disabled')
             cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
@@ -971,8 +618,6 @@ describe('Testing for the seeding report page', () => {
                 .should('exist')
                 .click()
             
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .should('not.be.disabled')
             cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
                 .should('not.be.disabled')
             cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
@@ -986,8 +631,6 @@ describe('Testing for the seeding report page', () => {
                 .should('exist')
                 .click()
             
-            cy.get('[data-cy=seeding-type-dropdown] > [data-cy=dropdown-input]')
-                .should('not.be.disabled')
             cy.get('[data-cy=crop-dropdown] > [data-cy=dropdown-input]')
                 .should('not.be.disabled')
             cy.get('[data-cy=area-dropdown] > [data-cy=dropdown-input]')
@@ -1010,9 +653,9 @@ describe('Testing for the seeding report page', () => {
                         'X-CSRF-TOKEN' : token,
                     },
                     body: {
-                        "name": "TEST SEEDING",
-                        "type": "farm_seeding",
-                        "timestamp": dayjs('2001-09-20').unix(),
+                        "name": "TEST TRANSPLANTING",
+                        "type": "farm_transplanting",
+                        "timestamp": dayjs('2019-01-20').unix(),
                         "done": "1",  //any seeding recorded is done.
                         "notes": {
                             "value": "This is a test log",
@@ -1034,38 +677,57 @@ describe('Testing for the seeding report page', () => {
                         },
                         "quantity": [
                             {
-                                "measure": "length", 
-                                "value": "5",  //total row feet
+                                "measure": "length",
+                                "value": "150",
                                 "unit": {
-                                    "id": "20", 
-                                    "resource": "taxonomy_term"
+                                    "uri": "http://localhost/taxonomy_term/20",
+                                    "id": "20",
+                                    "resource": "taxonomy_term",
+                                    "name": "ROW FEET"
                                 },
                                 "label": "Amount planted"
                             },
                             {
-                                "measure": "ratio", 
-                                "value": "38",
+                                "measure": "ratio",
+                                "value": "5",
                                 "unit": {
+                                    "uri": "http://localhost/taxonomy_term/38",
                                     "id": "38",
-                                    "resource": "taxonomy_term"
+                                    "resource": "taxonomy_term",
+                                    "name": "ROWS/BED"
                                 },
                                 "label": "Rows/Bed"
                             },
                             {
-                                "measure": "time", 
-                                "value": "0.5", 
+                                "measure": "count",
+                                "value": "4",
                                 "unit": {
+                                    "uri": "http://localhost/taxonomy_term/12",
+                                    "id": "12",
+                                    "resource": "taxonomy_term",
+                                    "name": "FLATS"
+                                },
+                                "label": "Flats"
+                            },
+                            {
+                                "measure": "time",
+                                "value": "2",
+                                "unit": {
+                                    "uri": "http://localhost/taxonomy_term/29",
                                     "id": "29",
-                                    "resource": "taxonomy_term"
+                                    "resource": "taxonomy_term",
+                                    "name": "HOURS"
                                 },
                                 "label": "Labor"
                             },
                             {
-                                "measure": "count", 
-                                "value": "1", 
+                                "measure": "count",
+                                "value": "1",
                                 "unit": {
+                                    "uri": "http://localhost/taxonomy_term/15",
                                     "id": "15",
-                                    "resource": "taxonomy_term"
+                                    "resource": "taxonomy_term",
+                                    "name": "PEOPLE"
                                 },
                                 "label": "Workers"
                             },
@@ -1085,10 +747,10 @@ describe('Testing for the seeding report page', () => {
 
             cy.get('[data-cy=start-date-select]')
                 .should('exist')
-                .type('2001-01-25')
+                .type('2019-01-25')
             cy.get('[data-cy=end-date-select]')
                 .should('exist')
-                .type('2001-12-25')
+                .type('2019-04-01')
             cy.get('[data-cy=generate-rpt-btn]').first()
                 .click()
         })
@@ -1102,12 +764,18 @@ describe('Testing for the seeding report page', () => {
                 .select('TOMATO')
             cy.get('[data-cy=dropdown-input-r0c2]')
                 .select('A')
-            cy.get('[data-cy=number-input-r0c10]')
-                .type('4')
-            cy.get('[data-cy=number-input-r0c11]')
-                .type('0.25')
+            cy.get('[data-cy=number-input-r0c3]')
+                .type('40')
+            cy.get('[data-cy=number-input-r0c4]')
+                .type('120')
+            cy.get('[data-cy=number-input-r0c6]')
+                .type('6')
+            cy.get('[data-cy=number-input-r0c7]')
+                .type('2')
+            cy.get('[data-cy=number-input-r0c8]')
+                .type('3.00')
 
-            cy.get('[data-cy=text-input-r0c13]')
+            cy.get('[data-cy=text-input-r0c9]')
                 .type('New Comment')
                 .blur()
 
@@ -1115,7 +783,7 @@ describe('Testing for the seeding report page', () => {
             cy.get('[data-cy=save-button-r0]')
                 .click({force:true})
 
-            cy.wrap(getRecord('/log.json?type=farm_seeding&id=' + logID)).as('check')
+            cy.wrap(getRecord('/log.json?type=farm_transplanting&id=' + logID)).as('check')
             cy.get('@check').should(function(response) {
                 expect(response.data.list[0].name).to.equal('TEST SEEDING')
             })

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.spec.js
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.spec.js
@@ -441,6 +441,498 @@ describe('Testing for the transplanting report page', () => {
         })
     })
 
+    context.only('has the correct totals in the seeding summary tables with hidden labor config', () => {
+        let logID = 0
+        let logID2 = 0
+        let logIDTransplant = 0
+        beforeEach(() =>{
+            cy.login('manager1', 'farmdata2')
+            .then(() => {
+                cy.wrap(getConfiguration()).as('def')
+                cy.wrap(getSessionToken()).as('token')
+            }) 
+            cy.get('@token').should(function(token) {
+                sessionToken = token
+            })
+            cy.get('@def').should(function(map) {
+                configMap = map.data
+                defaultConfig = configMap
+            })
+        })
+        beforeEach(() =>{
+            cy.wrap(getSessionToken())
+            .then(sessionToken => {
+                token = sessionToken
+                req = {
+                    url: '/log',
+                    method: 'POST',
+                    headers: {
+                        'X-Requested-With': 'XMLHttpRequest',
+                        'X-CSRF-TOKEN' : token,
+                    },
+                    body: {
+                        "name": "2019-03-27 TESTING CHUAU-2",
+                        "type": "farm_transplanting",
+                        "timestamp": dayjs('2001-10-16').unix(),
+                        "done": "1", 
+                        "notes": {
+                            "value": "<p>Testing Transplanting Report</p>\n",
+                            "format": "farm_format"
+                        },
+                        "asset": [{ 
+                            "id": "235",
+                            "resource": "farm_asset"
+                        }],
+                        "log_category": [{
+                            "id": "242",
+                            "resource": "taxonomy_term"
+                        }],
+                        "movement": {
+                            "area": [{
+                                "id": "182",
+                                "resource": "taxonomy_term"
+                            }]
+                        },
+                        "quantity": [
+                            {
+                                "measure": "length", 
+                                "value": "3",  
+                                "unit": {
+                                    "id": "20", 
+                                    "resource": "taxonomy_term"
+                                },
+                                "label": "Amount planted"
+                            },
+                            {
+                                "measure": "ratio", 
+                                "value": "3", 
+                                "unit": {
+                                    "id": "38",
+                                    "resource": "taxonomy_term"
+                                },
+                                "label": "Rows/Bed"
+                            },
+                            {
+                                "measure": "count", 
+                                "value": "2", 
+                                "unit": {
+                                    "id": "12",
+                                    "resource": "taxonomy_term"
+                                },
+                                "label": "Flats"
+                            },
+                            {
+                                "measure": "time", 
+                                "value": "0",  
+                                "unit": {
+                                    "id": "29",
+                                    "resource": "taxonomy_term"
+                                },
+                                "label": "Labor"
+                            },
+                            {
+                                "measure": "count", 
+                                "value": "0",
+                                "unit": {
+                                    "id": "15",
+                                    "resource": "taxonomy_term"
+                                },
+                                "label": "Workers"
+                            },
+                        ],
+                        "created": dayjs().unix(),
+                        "uid": {
+                            "id": "11",
+                            "resource": "user"
+                        },
+                        "log_owner": [{
+                            "id": "11",
+                            "resource": "user"
+                        }],
+                        "data": "{\"crop_tid\": \"166\"}"
+                    }
+                }
+                
+                reqTransplant = {
+                    url: '/log',
+                    method: 'POST',
+                    headers: {
+                        'X-Requested-With': 'XMLHttpRequest',
+                        'X-CSRF-TOKEN' : token,
+                    },
+                    body: {
+                        "name": "2019-03-27 TESTING CHUAU-2",
+                        "type": "farm_transplanting",
+                        "timestamp": dayjs('2001-10-16').unix(),
+                        "done": "1", 
+                        "notes": {
+                            "value": "<p>Testing Transplanting Report</p>\n",
+                            "format": "farm_format"
+                        },
+                        "asset": [{ 
+                            "id": "235",
+                            "resource": "farm_asset"
+                        }],
+                        "log_category": [{
+                            "id": "242",
+                            "resource": "taxonomy_term"
+                        }],
+                        "movement": {
+                            "area": [{
+                                "id": "182",
+                                "resource": "taxonomy_term"
+                            }]
+                        },
+                        "quantity": [
+                            {
+                                "measure": "length", 
+                                "value": "3",  
+                                "unit": {
+                                    "id": "20", 
+                                    "resource": "taxonomy_term"
+                                },
+                                "label": "Amount planted"
+                            },
+                            {
+                                "measure": "ratio", 
+                                "value": "3", 
+                                "unit": {
+                                    "id": "38",
+                                    "resource": "taxonomy_term"
+                                },
+                                "label": "Rows/Bed"
+                            },
+                            {
+                                "measure": "count", 
+                                "value": "2", 
+                                "unit": {
+                                    "id": "12",
+                                    "resource": "taxonomy_term"
+                                },
+                                "label": "Flats"
+                            },
+                            {
+                                "measure": "time", 
+                                "value": "0",  
+                                "unit": {
+                                    "id": "29",
+                                    "resource": "taxonomy_term"
+                                },
+                                "label": "Labor"
+                            },
+                            {
+                                "measure": "count", 
+                                "value": "0",
+                                "unit": {
+                                    "id": "15",
+                                    "resource": "taxonomy_term"
+                                },
+                                "label": "Workers"
+                            },
+                        ],
+                        "created": dayjs().unix(),
+                        "uid": {
+                            "id": "11",
+                            "resource": "user"
+                        },
+                        "log_owner": [{
+                            "id": "11",
+                            "resource": "user"
+                        }],
+                        "data": "{\"crop_tid\": \"166\"}"
+                    }
+                }
+                cy.request(req).as('create')
+                cy.get('@create').should(function(response) {
+                    expect(response.status).to.equal(201)
+                    logID = response.body.id
+                })
+                cy.request(reqTransplant).as('create2')
+                cy.get('@create2').should(function(response) {
+                    expect(response.status).to.equal(201)
+                    logIDTransplant = response.body.id
+                })
+            })
+            requiredConfig = {id: 1, labor: 'Required'}
+            cy.wrap(setConfiguration(requiredConfig, sessionToken)).as('updateConfig')
+            cy.get('@updateConfig')
+            .then(() => {
+                cy.reload()
+            })
+
+        })
+
+
+        afterEach(() => {
+            cy.wrap(setConfiguration(defaultConfig, sessionToken)).as('resetConfig')
+            cy.get('@resetConfig').should((response) => {
+                expect(response.status).to.equal(200)  // 201
+            }) 
+            cy.wrap(deleteRecord("/log/" + logID , sessionToken)).as('transplantingDelete1')
+            cy.get('@transplantingDelete1').should((response) => {
+                expect(response.status).to.equal(200)  // 200 - OK/success
+            })
+
+            cy.wrap(deleteRecord("/log/" + logIDTransplant , sessionToken)).as('transplantingDelete2')
+            cy.get('@transplantingDelete2').should((response) => {
+                expect(response.status).to.equal(200)  // 200 - OK/success
+            })
+
+        })
+
+        it('test summary table values when all logs have no labor data', () => {
+            req2 = {
+                url: '/log',
+                method: 'POST',
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest',
+                    'X-CSRF-TOKEN' : token,
+                },
+                body: {
+                    "name": "2019-03-27 TESTING CHUAU-2",
+                    "type": "farm_transplanting",
+                    "timestamp": dayjs('2001-10-16').unix(),
+                    "done": "1", 
+                    "notes": {
+                        "value": "<p>Testing Transplanting Report</p>\n",
+                        "format": "farm_format"
+                    },
+                    "asset": [{ 
+                        "id": "235",
+                        "resource": "farm_asset"
+                    }],
+                    "log_category": [{
+                        "id": "242",
+                        "resource": "taxonomy_term"
+                    }],
+                    "movement": {
+                        "area": [{
+                            "id": "182",
+                            "resource": "taxonomy_term"
+                        }]
+                    },
+                    "quantity": [
+                        {
+                            "measure": "length", 
+                            "value": "3",  
+                            "unit": {
+                                "id": "20", 
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Amount planted"
+                        },
+                        {
+                            "measure": "ratio", 
+                            "value": "3", 
+                            "unit": {
+                                "id": "38",
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Rows/Bed"
+                        },
+                        {
+                            "measure": "count", 
+                            "value": "2", 
+                            "unit": {
+                                "id": "12",
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Flats"
+                        },
+                        {
+                            "measure": "time", 
+                            "value": "0",  
+                            "unit": {
+                                "id": "29",
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Labor"
+                        },
+                        {
+                            "measure": "count", 
+                            "value": "0",
+                            "unit": {
+                                "id": "15",
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Workers"
+                        },
+                    ],
+                    "created": dayjs().unix(),
+                    "uid": {
+                        "id": "11",
+                        "resource": "user"
+                    },
+                    "log_owner": [{
+                        "id": "11",
+                        "resource": "user"
+                    }],
+                    "data": "{\"crop_tid\": \"166\"}"
+                }
+            }
+            cy.request(req2).as('create')
+                cy.get('@create').should(function(response) {
+                    expect(response.status).to.equal(201)
+                    logID2 = response.body.id
+                })
+
+            cy.get('[data-cy=start-date-select]')
+            .type('2001-10-16')
+            cy.get('[data-cy=end-date-select]')
+            .type('2001-10-17')
+            cy.get('[data-cy=generate-rpt-btn]')
+            .click()
+
+            cy.get('[data-cy=transplant-total-rowft]')
+                .should('have.text', '9')
+            cy.get('[data-cy=transplant-total-bedft]')
+            .should('have.text', '3')
+            cy.get('[data-cy=transplant-total-numTrays]')
+            .should('have.text', '6')
+            cy.get('[data-cy=transplant-total-hours]')
+            .should('have.text', '0')
+            cy.get('[data-cy=transplant-total-rowft-hour]')
+            .should('have.text', 'N/A')
+            cy.get('[data-cy=transplant-total-bedfr-hour]')
+            .should('have.text', 'N/A')
+            .then(() => {
+                cy.wrap(deleteRecord("/log/" + logID2 , sessionToken)).as('seedingDelete2')
+            })
+            cy.get('@seedingDelete2').should((response) => {
+                expect(response.status).to.equal(200)  // 200 - OK/success
+            })
+        })
+
+        it('test summary table values when there are mixed labor data', () => {
+            req2 = {
+                url: '/log',
+                method: 'POST',
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest',
+                    'X-CSRF-TOKEN' : token,
+                },
+                body: {
+                    "name": "2019-03-27 TESTING CHUAU-2",
+                    "type": "farm_transplanting",
+                    "timestamp": dayjs('2001-10-16').unix(),
+                    "done": "1", 
+                    "notes": {
+                        "value": "<p>Testing Transplanting Report</p>\n",
+                        "format": "farm_format"
+                    },
+                    "asset": [{ 
+                        "id": "235",
+                        "resource": "farm_asset"
+                    }],
+                    "log_category": [{
+                        "id": "242",
+                        "resource": "taxonomy_term"
+                    }],
+                    "movement": {
+                        "area": [{
+                            "id": "182",
+                            "resource": "taxonomy_term"
+                        }]
+                    },
+                    "quantity": [
+                        {
+                            "measure": "length", 
+                            "value": "3",  
+                            "unit": {
+                                "id": "20", 
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Amount planted"
+                        },
+                        {
+                            "measure": "ratio", 
+                            "value": "3", 
+                            "unit": {
+                                "id": "38",
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Rows/Bed"
+                        },
+                        {
+                            "measure": "count", 
+                            "value": "2", 
+                            "unit": {
+                                "id": "12",
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Flats"
+                        },
+                        {
+                            "measure": "time", 
+                            "value": "3",  
+                            "unit": {
+                                "id": "29",
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Labor"
+                        },
+                        {
+                            "measure": "count", 
+                            "value": "2",
+                            "unit": {
+                                "id": "15",
+                                "resource": "taxonomy_term"
+                            },
+                            "label": "Workers"
+                        },
+                    ],
+                    "created": dayjs().unix(),
+                    "uid": {
+                        "id": "11",
+                        "resource": "user"
+                    },
+                    "log_owner": [{
+                        "id": "11",
+                        "resource": "user"
+                    }],
+                    "data": "{\"crop_tid\": \"166\"}"
+                }
+            }
+
+            cy.request(req2).as('create')
+                cy.get('@create').should(function(response) {
+                    expect(response.status).to.equal(201)
+                    logID2 = response.body.id
+                })
+
+            cy.get('[data-cy=start-date-select]')
+            .type('2001-10-16')
+            cy.get('[data-cy=end-date-select]')
+            .type('2001-10-17')
+            cy.get('[data-cy=generate-rpt-btn]')
+            .click()
+        
+            cy.get('[data-cy=transplant-total-rowft]')
+                .should('have.text', '9')
+
+            cy.get('[data-cy=transplant-total-bedft]')
+            .should('have.text', '3')
+
+            cy.get('[data-cy=transplant-total-numTrays]')
+            .should('have.text', '6')
+
+            cy.get('[data-cy=transplant-total-hours]')
+            .should('have.text', '2')
+
+            cy.get('[data-cy=transplant-total-rowft-hour]')
+            .should('have.text', '4.5')
+
+            cy.get('[data-cy=transplant-total-bedfr-hour]')
+            .should('have.text', '1.5')
+            .then(() => {
+                cy.wrap(deleteRecord("/log/" + logID2 , sessionToken)).as('seedingDelete2')
+            })
+            cy.get('@seedingDelete2').should((response) => {
+                expect(response.status).to.equal(200)  // 200 - OK/success
+            })
+        })
+    })
+
     context('displays only relevant columns under certain conditions', () => {
         beforeEach(() => {
             cy.get('[data-cy=start-date-select]')
@@ -638,7 +1130,158 @@ describe('Testing for the transplanting report page', () => {
         })
     })
 
-    context.only('edit and delete buttons work', () => {
+    // context.only('edit and delete buttons work', () => {
+    //     let logID = 0
+
+    //     beforeEach(() => {
+    //         cy.wrap(getSessionToken())
+    //         .then(sessionToken => {
+    //             token = sessionToken
+    //             req = {
+    //                 url: '/log',
+    //                 method: 'POST',
+    //                 headers: {
+    //                     'X-Requested-With': 'XMLHttpRequest',
+    //                     'X-CSRF-TOKEN' : token,
+    //                 },
+    //                 body: {
+    //                     "name": "TEST TRANSPLANTING",
+    //                     "type": "farm_transplanting",
+    //                     "timestamp": dayjs('2001-09-20').unix(),
+    //                     "done": "1",  //any seeding recorded is done.
+    //                     "notes": {
+    //                         "value": "This is a test log",
+    //                         "format": "farm_format"
+    //                     },
+    //                     "asset": [{ 
+    //                         "id": "1",   //Associated planting
+    //                         "resource": "farm_asset"
+    //                     }],
+    //                     "log_category": [{
+    //                         "id": "242",
+    //                         "resource": "taxonomy_term"
+    //                     }],
+    //                     "movement": {
+    //                         "area": [{
+    //                             "id": "233",
+    //                             "resource": "taxonomy_term"
+    //                         }]
+    //                     },
+    //                     "quantity": [
+    //                         {
+    //                             "measure": "length", 
+    //                             "value": "5",  //total row feet
+    //                             "unit": {
+    //                                 "id": "20", 
+    //                                 "resource": "taxonomy_term"
+    //                             },
+    //                             "label": "Amount planted"
+    //                         },
+    //                         {
+    //                             "measure": "ratio", 
+    //                             "value": "38",
+    //                             "unit": {
+    //                                 "id": "38",
+    //                                 "resource": "taxonomy_term"
+    //                             },
+    //                             "label": "Rows/Bed"
+    //                         },
+    //                         {
+    //                             "measure": "count", 
+    //                             "value": "2",
+    //                             "unit": {
+    //                                 "id": "12",
+    //                                 "resource": "taxonomy_term"
+    //                             },
+    //                             "label": "Flats"
+    //                         },         
+    //                         {
+    //                             "measure": "time", 
+    //                             "value": "0.5", 
+    //                             "unit": {
+    //                                 "id": "29",
+    //                                 "resource": "taxonomy_term"
+    //                             },
+    //                             "label": "Labor"
+    //                         },
+    //                         {
+    //                             "measure": "count", 
+    //                             "value": "1", 
+    //                             "unit": {
+    //                                 "id": "15",
+    //                                 "resource": "taxonomy_term"
+    //                             },
+    //                             "label": "Workers"
+    //                         },
+    //                     ],
+    //                     "created": dayjs().unix(),
+    //                     "data": "1"
+    //                 }
+    //             }
+
+    //             cy.request(req).as('create')
+    //             cy.get('@create').should(function(response) {
+    //                 expect(response.status).to.equal(201)
+    //                 logID = response.body.id
+    //             })
+    //         })
+
+    //         cy.get('[data-cy=start-date-select]')
+    //             .should('exist')
+    //             .type('2019-01-25')
+    //         cy.get('[data-cy=end-date-select]')
+    //             .should('exist')
+    //             .type('2019-05-25')
+    //         cy.get('[data-cy=generate-rpt-btn]').first()
+    //             .click()
+    //     })
+
+    //     it('edits the database when a row is edited in the table', () => {
+    //         cy.get('[data-cy=edit-button-r0]')
+    //             .click()   
+    //         cy.get('[data-cy=date-input-r0c0]')
+    //             .type('2001-09-28')  
+    //         cy.get('[data-cy=dropdown-input-r0c1]')
+    //             .select('TOMATO')
+    //         cy.get('[data-cy=dropdown-input-r0c2]')
+    //             .select('A')
+    //         cy.get('[data-cy=number-input-r0c3]')
+    //             .clear()
+    //             .type('40')
+    //         cy.get('[data-cy=number-input-r0c4]')
+    //             .clear()
+    //             .type('100')
+
+    //         // cy.get('[data-cy=text-input-r0c9]')
+    //         //     .clear()
+    //         //     .type('New Comment')
+    //         //     .blur()
+
+    //         // Button is actionable, unfortunately it's not in view
+    //         cy.get('[data-cy=save-button-r0]')
+    //             .click({force:true})
+
+    //         cy.wrap(getRecord('/log.json?type=farm_transplanting&id=' + logID)).as('check')
+    //         cy.get('@check').should(function(response) {
+    //             expect(response.data.list[0].name).to.equal('TEST TRANSPLANTING')
+    //         })
+    //             .then(() => {
+    //                 cy.wrap(deleteRecord("/log/" + logID , token)).as('transplantingDelete')
+    //             })
+    //         cy.get('@transplantingDelete').should((response) => {
+    //             expect(response.status).to.equal(200)
+    //         })
+    //     })
+
+    //     it('deletes a log from the database when the delete button is pressed', () => {
+    //         cy.get('[data-cy=delete-button-r0]')
+    //             .click((response) => {
+    //                 expect(response.status).to.equal(200)
+    //             })
+    //     })
+    // })
+
+    context('edit and delete buttons work', () => {
         let logID = 0
 
         beforeEach(() => {
@@ -653,32 +1296,32 @@ describe('Testing for the transplanting report page', () => {
                         'X-CSRF-TOKEN' : token,
                     },
                     body: {
-                        "name": "TEST TRANSPLANTING",
+                        "name": "2019-03-27 TESTING CHUAU-2",
                         "type": "farm_transplanting",
-                        "timestamp": dayjs('2001-09-20').unix(),
-                        "done": "1",  //any seeding recorded is done.
+                        "timestamp": "1553644800",
+                        "done": "1", 
                         "notes": {
-                            "value": "This is a test log",
+                            "value": "<p>Testing Transplanting Report</p>\n",
                             "format": "farm_format"
                         },
                         "asset": [{ 
-                            "id": "1",   //Associated planting
+                            "id": "235",
                             "resource": "farm_asset"
                         }],
                         "log_category": [{
-                            "id": "240",
+                            "id": "242",
                             "resource": "taxonomy_term"
                         }],
                         "movement": {
                             "area": [{
-                                "id": "233",
+                                "id": "182",
                                 "resource": "taxonomy_term"
                             }]
                         },
                         "quantity": [
                             {
                                 "measure": "length", 
-                                "value": "5",  //total row feet
+                                "value": "3",  
                                 "unit": {
                                     "id": "20", 
                                     "resource": "taxonomy_term"
@@ -687,7 +1330,7 @@ describe('Testing for the transplanting report page', () => {
                             },
                             {
                                 "measure": "ratio", 
-                                "value": "38",
+                                "value": "3", 
                                 "unit": {
                                     "id": "38",
                                     "resource": "taxonomy_term"
@@ -696,16 +1339,16 @@ describe('Testing for the transplanting report page', () => {
                             },
                             {
                                 "measure": "count", 
-                                "value": "10",
+                                "value": "2", 
                                 "unit": {
-                                    "id": "10",
+                                    "id": "12",
                                     "resource": "taxonomy_term"
                                 },
                                 "label": "Flats"
-                            },         
+                            },
                             {
                                 "measure": "time", 
-                                "value": "0.5", 
+                                "value": "1",  
                                 "unit": {
                                     "id": "29",
                                     "resource": "taxonomy_term"
@@ -714,7 +1357,7 @@ describe('Testing for the transplanting report page', () => {
                             },
                             {
                                 "measure": "count", 
-                                "value": "1", 
+                                "value": "1",
                                 "unit": {
                                     "id": "15",
                                     "resource": "taxonomy_term"
@@ -722,8 +1365,16 @@ describe('Testing for the transplanting report page', () => {
                                 "label": "Workers"
                             },
                         ],
-                        "created": dayjs().unix(),
-                        "data": "1"
+                        "created": "1553644800",
+                        "uid": {
+                            "id": "11",
+                            "resource": "user"
+                        },
+                        "log_owner": [{
+                            "id": "11",
+                            "resource": "user"
+                        }],
+                        "data": "{\"crop_tid\": \"166\"}"
                     }
                 }
 
@@ -731,15 +1382,15 @@ describe('Testing for the transplanting report page', () => {
                 cy.get('@create').should(function(response) {
                     expect(response.status).to.equal(201)
                     logID = response.body.id
+                    console.log(logID)
                 })
             })
-
             cy.get('[data-cy=start-date-select]')
                 .should('exist')
-                .type('2019-01-25')
+                .type('2019-03-27')
             cy.get('[data-cy=end-date-select]')
                 .should('exist')
-                .type('2019-05-25')
+                .type('2019-03-27')
             cy.get('[data-cy=generate-rpt-btn]').first()
                 .click()
         })
@@ -749,16 +1400,16 @@ describe('Testing for the transplanting report page', () => {
                 .click()   
             cy.get('[data-cy=date-input-r0c0]')
                 .type('2001-09-28')  
-            cy.get('[data-cy=dropdown-input-r0c1]')
-                .select('TOMATO')
-            cy.get('[data-cy=dropdown-input-r0c2]')
-                .select('A')
+            // cy.get('[data-cy=dropdown-input-r0c1]')
+            //     .select('TOMATO')
+            // cy.get('[data-cy=dropdown-input-r0c2]')
+            //     .select('A')
             cy.get('[data-cy=number-input-r0c3]')
                 .clear()
                 .type('40')
-            cy.get('[data-cy=number-input-r0c4]')
-                .clear()
-                .type('100')
+            // cy.get('[data-cy=number-input-r0c4]')
+            //     .clear()
+            //     .type('100')
 
             // cy.get('[data-cy=text-input-r0c9]')
             //     .clear()
@@ -771,7 +1422,7 @@ describe('Testing for the transplanting report page', () => {
 
             cy.wrap(getRecord('/log.json?type=farm_transplanting&id=' + logID)).as('check')
             cy.get('@check').should(function(response) {
-                expect(response.data.list[0].name).to.equal('TEST TRANSPLANTING')
+                expect(response.data.list[0].name).to.equal('2019-03-27 TESTING CHUAU-2')
             })
                 .then(() => {
                     cy.wrap(deleteRecord("/log/" + logID , token)).as('transplantingDelete')
@@ -947,6 +1598,25 @@ describe('Testing for the transplanting report page', () => {
                     cy.get('[data-cy=alert-err-handler]')
                     .click()
                     .should('not.visible')
+                    .then(() => {
+                        cy.get('[data-cy=alert-err-handler]')
+                        .should('be.visible')
+                        cy.window().its('scrollY').should('equal', 0)
+                        cy.get('[data-cy=alert-err-handler]')
+                        .click()
+                        .should('not.visible')
+                    }) 
+            })
+        })
+    
+            it('fail the session token API: network error', () => {
+                cy.intercept('GET', 'restws/session/token', { forceNetworkError: true }).as('failedSessionTok')
+    
+                cy.visit('/farm/fd2-barn-kit/transplantingReport')
+                cy.wait('@failedSessionTok')
+                    .then(() => {
+                        cy.get('[data-cy=alert-err-handler]')
+        
                 }) 
         })
 


### PR DESCRIPTION
__Pull Request Description__

Closes #415. This PR adds the Transplanting Report sub-tab to the Barn Kit module. It's functionality is very similar to the Seeding Report but simpler because we're only dealing with transplanting logs instead of two types of seedings. 

These issues must be addressed prior to review for merge into upstream: 
- [x] Modify the edit and delete buttons on the Transplanting Report page and update their Cypress test to make sure they work properly.
- [x] Add the configuration piece to the summary tables so that statistics concerning time are calculated correctly and appear on when appropriate. 
- [x] Add a test for the configuration and summary table piece. 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
