### PR TITLE
Issue #553 FD2 Configuration Module Drupal Error

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_config/fd2_config.module
+++ b/farmdata2_modules/fd2_tabs/fd2_config/fd2_config.module
@@ -82,7 +82,7 @@ function fd2_config_entity_property_info() {
   );
 
   $info['fd2_config']['properties']['labor'] = array(
-    'labor' => t('Labor data configuration'),
+    'label' => t('Labor data configuration'),
     'description' => t('Whether labor data is Required, Optional or Hidden'),
     'type' => 'text',
     'schema field' => 'labor',


### PR DESCRIPTION
__Pull Request Description__

Fixes #553. Fixed typo which fixed the issue. The token in the database failed to match the label because it was declared as "labor" instead of "label. 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
