### PR TITLE
FarmOSAPI: Remove Only in Cypress Test

### DIFF
--- a/farmdata2_modules/fd2_tabs/resources/FarmOSAPI.spec.js
+++ b/farmdata2_modules/fd2_tabs/resources/FarmOSAPI.spec.js
@@ -859,7 +859,7 @@ describe('API Request Functions', () => {
             })
         })
     
-    context.only('test configuration functions', () => {
+    context('test configuration functions', () => {
         
         it('gets an existing configuration log', () => {
             cy.wrap(getConfiguration()).as('done')


### PR DESCRIPTION
__Pull Request Description__

Removes a lingering only inside of the FarmOSAPI test file. 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
