### PR TITLE
Fixed Average Row Feet/Hour Calculation

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/seedingReport.html
@@ -527,7 +527,7 @@
                     let sumRowFeet = 0
                     tableData.map(h => {
                         if(parseFloat(h.data[10]) != 0 && parseFloat(h.data[11]) != 0) {
-                            sumRowFeet = sumRowFeet + parseFloat(h.data[5])        
+                            sumRowFeet = sumRowFeet + parseFloat(h.data[4])        
                         }
                     })
                     return (Math.round(sumRowFeet*100))/100


### PR DESCRIPTION
Closes #574. Fixed a simple miscalculation for the Row Feet/Hours in the direct summary of the Seeding Report. Th e2e test remains unchanged because it will be addressed in another issue.

__Pull Request Description__

<Add description>

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
