### PR TITLE
Set permissions on .fd2gids for WSL/Linux

### DIFF
--- a/docker/dev/startup.bash
+++ b/docker/dev/startup.bash
@@ -21,11 +21,13 @@ echo "fd2dev" | sudo -S usermod -a -G $HOST_DOCKER_GID fd2dev
 echo "fd2dev" | sudo -S chgrp +$HOST_DOCKER_GID /var/run/docker.sock
 echo "fd2dev" | sudo -S chmod 775 /var/run/docker.sock
 
-# Ensure that the fd2grp has RW access to mounted FarmData2 directory.
+# Ensure that the fd2grp has RW access to mounted FarmData2 and .fd2 directories.
 # This probably is not necessary as in linux the group will reflect
 # the host group.  But it does make things consistent across macOS and linux.
 echo "fd2dev" | sudo -S chgrp -R fd2grp /home/fd2dev/FarmData2
 echo "fd2dev" | sudo -S chmod -R g+rw /home/fd2dev/FarmData2
+echo "fd2dev" | sudo -S chgrp -R fd2grp /home/fd2dev/.fd2
+echo "fd2dev" | sudo -S chmod -R g+rw /home/fd2dev/.fd2
 
 # Ensure that the dbus service is running.
 echo "fd2dev" | sudo /etc/init.d/dbus restart

--- a/docker/dev/startup.bash
+++ b/docker/dev/startup.bash
@@ -5,6 +5,14 @@
 rm /tmp/.X11-unix/X1
 rm /tmp/.X1-lock
 
+# Ensure that the fd2grp has RW access to mounted FarmData2 and .fd2 directories.
+# This probably is not necessary as in linux the group will reflect
+# the host group.  But it does make things consistent across macOS and linux.
+echo "fd2dev" | sudo -S chgrp -R fd2grp /home/fd2dev/FarmData2
+echo "fd2dev" | sudo -S chmod -R g+rw /home/fd2dev/FarmData2
+echo "fd2dev" | sudo -S chgrp -R fd2grp /home/fd2dev/.fd2
+echo "fd2dev" | sudo -S chmod -R g+rw /home/fd2dev/.fd2
+
 # Ensure that the fd2dev user is in a group that has RW permission to
 # the docker.sock file.  This will allow fd2dev to use the docker on docker
 # to interact with containers within the development environment.
@@ -20,14 +28,6 @@ fi
 echo "fd2dev" | sudo -S usermod -a -G $HOST_DOCKER_GID fd2dev
 echo "fd2dev" | sudo -S chgrp +$HOST_DOCKER_GID /var/run/docker.sock
 echo "fd2dev" | sudo -S chmod 775 /var/run/docker.sock
-
-# Ensure that the fd2grp has RW access to mounted FarmData2 and .fd2 directories.
-# This probably is not necessary as in linux the group will reflect
-# the host group.  But it does make things consistent across macOS and linux.
-echo "fd2dev" | sudo -S chgrp -R fd2grp /home/fd2dev/FarmData2
-echo "fd2dev" | sudo -S chmod -R g+rw /home/fd2dev/FarmData2
-echo "fd2dev" | sudo -S chgrp -R fd2grp /home/fd2dev/.fd2
-echo "fd2dev" | sudo -S chmod -R g+rw /home/fd2dev/.fd2
 
 # Ensure that the dbus service is running.
 echo "fd2dev" | sudo /etc/init.d/dbus restart

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - farmdev_home_fd2.1:/home/fd2dev  # preserve home dir on volume.
       - farmos_db:/home/fd2dev/FarmData2/docker/db  # use volume for performance.
-      - ~/.fd2gids:/home/fd2dev/.fd2/gids  # mount GID information.
+      - ${HOME}/.fd2gids:/home/fd2dev/.fd2/gids  # mount GID information.
     ports:
       - 5901:5901
       - 6901:6901
@@ -105,7 +105,7 @@ services:
       - //var/run/docker.sock:/var/run/docker.sock
       - farmdev_home_fd2.1:/home/fd2dev  # preserve home dir on volume.
       - farmos_db:/home/fd2dev/FarmData2/docker/db  # use volume for performance.
-      - ~/.fd2gids:/home/fd2dev/.fd2/gids  # mount GID information.
+      - ${HOME}/.fd2gids:/home/fd2dev/.fd2/gids  # mount GID information.
     ports:
       - 5901:5901
       - 6901:6901

--- a/docker/fd2-up.bash
+++ b/docker/fd2-up.bash
@@ -269,7 +269,8 @@ echo "  fd2 gid files created."
 if [ "$PROFILE" == "linux" ] || [ "$PROFILE" == "windows" ];
 then
   echo "  Assigning .fd2gids to fd2grp group..."
-  sudo chmod -R g+rw ~/.fd2gids
+  chgrp -R fd2grp ~/.fd2gids
+  chmod -R g+rw ~/.fd2gids
   echo "  .fd2gids assigned to fd2grp group."
 fi
 


### PR DESCRIPTION
__Pull Request Description__

Changes the permissions on the `.fd2gids` directory and files that are created by the `fd2_up.bash` script so that they are writeable by the `fd2grp` group.  It is hoped that this will allow the `.fd2gids` directory to be successfully mounted into the dev container on subsequent starts.

Closes #584

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
