### PR TITLE
Updated fd2-down.bash to remove dev container.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -224,4 +224,4 @@ The farmOS/drupal database used by FarmData2 is stored in a Docker volume (`dock
 
 #### The Dev Environment ####
 
-The `home/fd2dev` directory in the FarmData2 development development environment is stored in a Docker volume (`docker_farmdev_home_fd2.x`).  In addition, the `fd2_dev` container is not deleted by `fd2-up.bash` or `fd2-down.bash`.  This allows individual customizations of the development environment to persist across runs. However, if it is necessary to make breaking changes to the development environment the version number of the container and the volume will be bumped in the `docker/docker-compose.yml` file which will create a new container and use a new blank volume.
+The `home/fd2dev` directory in the FarmData2 development development environment is stored in a Docker volume (`docker_farmdev_home_fd2.x`).  If it is necessary to make breaking changes to the development environment the version number of the container and the volume will be bumped in the `docker/docker-compose.yml` file which will create a new container and use a new blank volume the next time `fd2-up.bash` is run.

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,21 +12,21 @@ There are 5 containers involved in the FarmData2 system:
     * A noVNC server accessible via port 6901 on the `localhost`.
     * An XFCE4 desktop with many standard development tools.
     * The Cypress testing framework configured for the FarmData2 project.
-  * The FarmData2 repository from the host machine is mounted into the default user's home direcotry in this container.
+  * The FarmData2 repository from the host machine is mounted into the default user's home directory in this container.
 * `fd2_farmdata2`
   * FarmData2 runs in this container.  
-  * The server is accessible at `fd2_farmdata2` in the FarmData2 development enviornment.  It is also exposed on port 80 of the `localhost`.  
+  * The server is accessible at `fd2_farmdata2` in the FarmData2 development environment.  It is also exposed on port 80 of the `localhost`.  
   * The code from the FarmData2 repository is mounted into this container and runs on the underlying farmOS and Drupal services.
 * `fd2_mariaDB`
   * The MariaDB Database service that manages all of the FarmData2 data runs in this container.  
   * The actual database files used by MariaDB are stored in a external Docker Volume for performance and persistence.
 * `fd2_api`
   * An custom api for FarmData2 that accesses the farmOS database in the `fd2_mariaDB` container.  This api provides api endpoints that are specialized for FarmData2 and supplement the more general farmOS api endpoints.
-  * The api code is mounted from the FarmData2 repository into this container and is monitored for changes so that they are reflected in the endpoints avaialble and the results returned.
-  * This api is accssible at `fd2_api` in the FarmData2 development enviornment.  It is also exposed on port 8080 of the `localhost`.  
+  * The api code is mounted from the FarmData2 repository into this container and is monitored for changes so that they are reflected in the endpoints available and the results returned.
+  * This api is accessible at `fd2_api` in the FarmData2 development environment.  It is also exposed on port 8080 of the `localhost`.  
 * `fd2_phpmyadmin`
   * A PHPMyAdmin service runs in this container to assist developers with backend API development.
-  * The PHPMyadmin service is accessible at `fd2_phpmyadmin` in the FarmData2 development enviornment.  It is also exposed on port 8181 of the `localhost`.  
+  * The PHPMyadmin service is accessible at `fd2_phpmyadmin` in the FarmData2 development environment.  It is also exposed on port 8181 of the `localhost`.  
 
 ## The Images
 
@@ -43,7 +43,7 @@ The `docker/build-images.bash` script builds the images and pushes them to docke
 Each image that can be build has its own directory in the `docker` directory (e.g. `api`, `dev`, `farmos`, `mariaDB`, `phpmyadmin`).  Each of those directories contains a `Dockerfile` and any additional files that are needed to build the image.  In addition, each of these directories contains the following files:
 * `repo.txt`: required file that specifies the image name and tag to be used for the image when it is built and pushed to the [farmdata2](https://hub.docker.com/u/farmdata2) dockerhub repository.  
 * `before.bash`: Optional script that is run by `build-images.bash` just before the image is built.  This is useful for adding files from outside the build context into the build context.
-* `after.bash`: Optinal script that is run by `build-images.bash` just after the image is built. This is useful for doing any cleanup from operations performed by the `before.bash` script.
+* `after.bash`: Optional script that is run by `build-images.bash` just after the image is built. This is useful for doing any cleanup from operations performed by the `before.bash` script.
 
 Note: In order to push the images it is necessary to log in to dockerhub with an account with write permission to the [farmdata2](https://hub.docker.com/u/farmdata2) dockerhub repository.
 
@@ -51,6 +51,6 @@ Note: In order to push the images it is necessary to log in to dockerhub with an
 
 When an image is modified the tag in its `repo.txt` file should be incremented.  For example, if `repo.txt` contains `dev:fd2.1` and a new version is being created, this file should be edited to contain `dev:fd2.2`.  This will cause a new image with the new tag to be built and pushed to dockerhub.
 
-When a new tag is created and pushed, the `docker-compose.yml` file should also be updated to use the new tag for the image.  This ensures that the latest images will be pulled for developers the next time they start FarmData2 after they synch with the upstream repository.
+When a new tag is created and pushed, the `docker-compose.yml` file should also be updated to use the new tag for the image.  This ensures that the latest images will be pulled for developers the next time they use `fd2-up.bash` to start FarmData2 after they synch with the upstream repository.
 
-If significant changes are made to the `dev` container then it may also be necessary to bump the version number of the Docker volume that is used to store the fd2dev user's home directory.
+If significant changes are made to the `dev` container then it may also be necessary to bump the version number of the Docker volume that is used to store the fd2dev user's home directory. This will cause a new volume to be created for the user's home directory.

--- a/docker/fd2-down.bash
+++ b/docker/fd2-down.bash
@@ -21,8 +21,7 @@ echo "Deleting containers..."
 docker rm fd2_mariadb
 docker rm fd2_phpmyadmin --volumes  # remove /sessions volume created.
 docker rm fd2_farmdata2
+docker rm fd2_dev
 docker rm fd2_api
-
-# Note don't delete fd2_dev so that customizations persist.
 
 echo "Done."


### PR DESCRIPTION
__Pull Request Description__

Updates fd2-down.bash to remove the dev container when FarmData2 is shut down.  There was an issue when running in WSL that is addressed by this fix.  The fix is a little unsatisfactory in that the writeable later in the dev container is lost.  Thus, any local installs done are lost when FarmData2 is taken down.  If this presents a challenge for lots of developers then this issue should be revisited.

This closes #584.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
