### PR TITLE
Added ENV var to prevent WSL warning for Codium

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -58,6 +58,10 @@ COPY vscodium.bash .
 RUN ./vscodium.bash \
  && rm vscodium.bash
 
+# Add environment variable to /etc/profile so that VSCodium
+# launches on Windows with WSL without a warning.
+ENV DONT_PROMPT_WSL_INSTALL=1
+
 # Install Docker because we use Docker On Docker to allow some scripts
 # (e.g. docker/setDB.bash and buildSampleDB.bash) to stop and start 
 # containers.


### PR DESCRIPTION
__Pull Request Description__

When running VSCodium on Windows/WSL it detected that it was running in Docker and suggested using it under WSL directly. The added environment variable silences this warning.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
