### PR TITLE
Fixed broken FD2School links

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_school/README.md
+++ b/farmdata2/farmdata2_modules/fd2_school/README.md
@@ -6,13 +6,13 @@ If you use these activities, please keep in mind that they were created for use 
 
 ## The Activities
 
-- 00 - Introduction to FOSS & The FarmData2 Community [ [docx](activities/01-IntroToFarmData2.docx) | [pdf](activities/01-IntroToFarmData2.pdf) ]
-- 01 - FarmData2 Developer Install [ [docx](activities/02-DeveloperInstall.docx) | [pdf](activities/02-DeveloperInstall.pdf) ]
-- 02 - HTML Technology Spike [ [docx](activities/03-HTMLSpike.docx) | [pdf](activities/03-HTMLSpike.pdf) ]
-- 03 - Vue Data Binding Technology Spike [ [docx](activities/04-VueDataBindingSpike.docx) | [pdf](activities/04-VueDataBindingSpike.pdf) ]
-- 04 - Vue Events and JavaScript Functions Technology Spike [ [docx](activities/05-VueJSEventsSpike.docx) | [pdf](activities/05-VueJSEventsSpike.pdf) ]
-- 05 - Web APIs Technology Spike [ [docx](activities/06-WebAPIsSpike.docx) | [pdf](activities/06-WebAPIsSpike.pdf) ]
-- 06 - FarmOS API Technology Spike [ [docx](activities/07-FarmOSAPISpike.docx) | [pdf](activities/07-FarmOSAPISpike.pdf) ]
+- 00 - Introduction to FOSS & The FarmData2 Community [ [docx](activities/00-IntroToFarmData2.docx) | [pdf](activities/00-IntroToFarmData2.pdf) ]
+- 01 - FarmData2 Developer Install [ [docx](activities/01-DeveloperInstall.docx) | [pdf](activities/01-DeveloperInstall.pdf) ]
+- 02 - HTML Technology Spike [ [docx](activities/02-HTMLSpike.docx) | [pdf](activities/02-HTMLSpike.pdf) ]
+- 03 - Vue Data Binding Technology Spike [ [docx](activities/03-VueDataBindingSpike.docx) | [pdf](activities/03-VueDataBindingSpike.pdf) ]
+- 04 - Vue Events and JavaScript Functions Technology Spike [ [docx](activities/04-VueJSEventsSpike.docx) | [pdf](activities/04-VueJSEventsSpike.pdf) ]
+- 05 - Web APIs Technology Spike [ [docx](activities/05-WebAPIsSpike.docx) | [pdf](activities/05-WebAPIsSpike.pdf) ]
+- 06 - FarmOS API Technology Spike [ [docx](activities/06-FarmOSAPISpike.docx) | [pdf](activities/06-FarmOSAPISpike.pdf) ]
 - 07 - FarmData2 Pages and Patterns (in development)
 - 08 - Cypress Testing (in development)
 


### PR DESCRIPTION
__Pull Request Description__

The activities in the `FD2School/materials` directory were renumbered but the links were not updated.  This PR updates the links to match the filenames of the materials.

Co-authored-by: John MacCormick <jmac@dickinson.edu>

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
