### PR TITLE
Clarified and fixed CustomTable data-cy attributes for input elements

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_example/ui/ui.table.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_example/ui/ui.table.spec.js
@@ -26,7 +26,7 @@ describe('Test the behavior of the CustomTableComponent', () => {
             .should('have.text', 'Green')
         cy.get('[data-cy=r0-Count]')
             .should('have.text', '5')
-        cy.get('[data-cy=r0-boolean-input]')
+        cy.get('[data-cy=r0-Purchased-input]')
             .should('be.checked')
         cy.get('[data-cy=edit-row-id]')
             .should('have.text','')
@@ -54,7 +54,7 @@ describe('Test the behavior of the CustomTableComponent', () => {
         cy.get('[data-cy=r0-edit-button')
             .click()
 
-        cy.get('[data-cy=r0-text-input')
+        cy.get('[data-cy=r0-Item-input')
             .clear()
             .type('Tee Shirts')
         

--- a/farmdata2/farmdata2_modules/resources/CustomTableComponent.js
+++ b/farmdata2/farmdata2_modules/resources/CustomTableComponent.js
@@ -26,15 +26,12 @@ catch(err) {
  * <tr><td>hi</td>                   <td>The ith th element, i=0,1,2...</td></tr>
  * <tr><td>edit-header</td>          <td>The th element for the edit button column</td></tr>
  * <tr><td>save-header</td>          <td>The th element for the save button column</td></tr>
- * <tr><td>ri</td>                   <td>The tr checkbox element for the ith table row if custom buttons or deleting is enabled, i=0,1,2,...</td></tr>
+ * <tr><td>ri-cbutton</tc>           <td>The td element containing the checkbox for the ith table row if it appears. i=0,1,2...</td></tr>
+ * <tr><td>ri-cbuttonCheckbox</td>   <td>The checkbox element for the ith table row if custom buttons or deleting is enabled, i=0,1,2,...</td></tr>
  * <tr><td>ri</td>                   <td>The tr element for the ith table row, i=0,1,2,...</td></tr>
  * <tr><td>td-ricj</td>              <td>The td element in the ith row and jth column, i,j=0,1,2...</td></tr>
- * <tr><td>ri-columnHeader</td>      <td>The div for plain text in the ith row and jth column, i,j=0,1,2....</td></tr>
- * <tr><td>ri-text-input</td>        <td>The text input in the ith row and jth column in edit mode, i,j=0,1,2....</td></tr>
- * <tr><td>ri-dropdown-input</td>    <td>The select input in the ith row and jth column in edit mode, i,j=0,1,2....</td></tr>
- * <tr><td>ri-date-input</td>        <td>The date input in the ith row and jth column in edit mode, i,j=0,1,2....</td></tr>
- * <tr><td>ri-regex-input</td>       <td>The regex input in the ith row and jth column in edit mode, i,j=0,1,2....</td></tr>
- * <tr><td>ri-boolean-input</td>     <td>The boolean input in the ith row and jth column in edit mode, i,j=0,1,2....</td></tr>
+ * <tr><td>ri-*</td>                 <td>The div for plain text in the ith row and the indicated column, * is replaced by the column header. i,j=0,1,2....</td></tr>
+ * <tr><td>ri-*-input</td>           <td>The text input element ith row and the indicated column in edit mode, * is replaced by the column header. i=0,1,2....</td></tr>
  * <tr><td>ri-edit-button</td>       <td>The edit button in the ith row, i=0,1,2....</td></tr>
  * <tr><td>ri-save-button</td>       <td>The save button in the ith row, i=0,1,2....</td></tr>
  * <tr><td>ri-cancel-button</td>     <td>The cancel button in the ith row, i=0,1,2....</td></tr>
@@ -124,7 +121,7 @@ let CustomTableComponent = {
                     :data-cy="'r'+ri">
                         <td
                         v-if="customButtons.length > 0 || canDelete || csvName != ''" 
-                        :data-cy="'r'+ri+'cbutton'+ri"
+                        :data-cy="'r'+ri+'-cbutton'"
                         style="text-align:center">
                             <input
                             :disabled="editDeleteDisabled"
@@ -147,13 +144,13 @@ let CustomTableComponent = {
                                         
                             <textarea 
                             v-if="rowToEditIndex==ri && columns[ci].inputType.type == 'text'" 
-                            :data-cy="'r'+ri+'-'+columns[ci].inputType.type+'-input'"
+                            :data-cy="'r'+ri+'-'+columns[ci].header+'-input'"
                             v-model="editedRowData.data[ci]" 
                             @focusout="changedCell(ci)"></textarea>
                                         
                             <select 
                             v-if="rowToEditIndex==ri && columns[ci].inputType.type == 'dropdown'" 
-                            :data-cy="'r'+ri+'-'+columns[ci].inputType.type+'-input'"
+                            :data-cy="'r'+ri+'-'+columns[ci].header+'-input'"
                             v-model="editedRowData.data[ci]" 
                             @focusout="changedCell(ci)">
                                 <option v-for="option in columns[ci].inputType.value">{{ option }}</option>
@@ -161,14 +158,14 @@ let CustomTableComponent = {
                                         
                             <input 
                             v-if="rowToEditIndex==ri && columns[ci].inputType.type == 'date'" 
-                            :data-cy="'r'+ri+'-'+columns[ci].inputType.type+'-input'"
+                            :data-cy="'r'+ri+'-'+columns[ci].header+'-input'"
                             type="date" 
                             v-model="editedRowData.data[ci]" 
                             @focusout="changedCell(ci)">
                                         
                             <regex-input 
                             v-if="rowToEditIndex==ri && columns[ci].inputType.type == 'regex'"
-                            :data-cy="'r'+ri+'-'+columns[ci].inputType.type+'-input'" 
+                            :data-cy="'r'+ri+'-'+columns[ci].header+'-input'" 
                             :reg-exp="columns[ci].inputType.regex"
                             :default-val="editedRowData.data[ci]"
                             set-type="number" 
@@ -179,7 +176,7 @@ let CustomTableComponent = {
 
                             <input 
                             v-if="columns[ci].inputType.type == 'boolean'" 
-                            :data-cy="'r'+ri+'-'+columns[ci].inputType.type+'-input'" 
+                            :data-cy="'r'+ri+'-'+columns[ci].header+'-input'" 
                             type="checkbox" 
                             :disabled="rowToEditIndex!=ri || !editDeleteDisabled"
                             v-model="rows[ri].data[ci]">

--- a/farmdata2/farmdata2_modules/resources/CustomTableComponent.spec.comp.js
+++ b/farmdata2/farmdata2_modules/resources/CustomTableComponent.spec.comp.js
@@ -70,21 +70,21 @@ describe('custom table component', () => {
             cy.get('[data-cy=r0-Color]').should('have.text', 'Green')
             cy.get('[data-cy=r0-Count]').should('have.text', '5')
             cy.get('[data-cy=r0-Date]').should('have.text', '2020-01-01')
-            cy.get('[data-cy=r0-boolean-input]').should('be.checked')
+            cy.get('[data-cy=r0-Purchased-input]').should('be.checked')
 
             cy.get('[data-cy=r1-ID]').should('have.text', '5')
             cy.get('[data-cy=r1-Item]').should('have.text', 'Pants')
             cy.get('[data-cy=r1-Color]').should('have.text', 'Blue')
             cy.get('[data-cy=r1-Count]').should('have.text', '12')
             cy.get('[data-cy=r1-Date]').should('have.text', '2020-05-01')
-            cy.get('[data-cy=r1-boolean-input]').should('be.checked')
+            cy.get('[data-cy=r1-Purchased-input]').should('be.checked')
 
             cy.get('[data-cy=r2-ID]').should('have.text', '9')
             cy.get('[data-cy=r2-Item]').should('have.text', 'Hat')
             cy.get('[data-cy=r2-Color]').should('have.text', 'Black')
             cy.get('[data-cy=r2-Count]').should('have.text', '8')
             cy.get('[data-cy=r2-Date]').should('have.text', '2020-03-01')
-            cy.get('[data-cy=r2-boolean-input]').should('not.be.checked')
+            cy.get('[data-cy=r2-Purchased-input]').should('not.be.checked')
         })
 
         it('prop change to the rows updates table', () => {
@@ -95,7 +95,7 @@ describe('custom table component', () => {
             cy.get('[data-cy=r0-Color]').should('have.text', 'Grey')
             cy.get('[data-cy=r0-Count]').should('have.text', '16')
             cy.get('[data-cy=r0-Date]').should('have.text', '2001-10-16')
-            cy.get('[data-cy=r0-boolean-input]').should('not.be.checked')
+            cy.get('[data-cy=r0-Purchased-input]').should('not.be.checked')
         })
 
         it('prop change to the column visibility updates table', () => {
@@ -107,7 +107,7 @@ describe('custom table component', () => {
             cy.get('[data-cy=r0-Color]').should('have.text', 'Grey')
             cy.get('[data-cy=r0-Count]').should('have.text', '16')
             cy.get('[data-cy=r0-Date]').should('have.text', '2001-10-16')
-            cy.get('[data-cy=r0-boolean-input]').should('not.be.checked')
+            cy.get('[data-cy=r0-Purchased-input]').should('not.be.checked')
         })
         
         it('renders HTML elements found in strings', () => {
@@ -151,7 +151,7 @@ describe('custom table component', () => {
                 .should('exist')
                 .click()
 
-            cy.get('[data-cy=r0-text-input]')
+            cy.get('[data-cy=r0-Item-input]')
                 .clear()
                 .type('Socks')
 
@@ -171,7 +171,7 @@ describe('custom table component', () => {
                 .should('exist')
                 .click()
 
-            cy.get('[data-cy=r0-text-input]')
+            cy.get('[data-cy=r0-Item-input]')
                 .clear()
                 .type('Shirt')
 
@@ -223,7 +223,7 @@ describe('custom table component', () => {
             cy.get('[data-cy=r0-edit-button]')
                 .click()
 
-            cy.get('[data-cy=r0-text-input]')
+            cy.get('[data-cy=r0-Item-input]')
                 .clear()
                 .type('Hoodie')
 
@@ -319,7 +319,7 @@ describe('custom table component', () => {
             cy.get('[data-cy=r0-edit-button]')
                 .click()
 
-            cy.get('[data-cy=r0-text-input]')
+            cy.get('[data-cy=r0-Item-input]')
                 .clear()
                 .type('Bomber Jacket')
                 .clear()
@@ -377,7 +377,7 @@ describe('custom table component', () => {
             cy.get('[data-cy=r0-edit-button')
                 .first().click()
 
-            cy.get('[data-cy=r0-text-input]')
+            cy.get('[data-cy=r0-Item-input]')
                 .clear()
                 .type('Hello there!')
             
@@ -453,15 +453,17 @@ describe('custom table component', () => {
 
             cy.get('[data-cy=r0-ID]') // This is a no-input
                 .should("exist")
-            cy.get('[data-cy=r0-text-input]')
+            cy.get('[data-cy=r0-Item-input]')
                 .should("exist")
-            cy.get('[data-cy=r0-dropdown-input]')
+            cy.get('[data-cy=r0-Size-input]')
+                .should("not.exist")  // not visible
+            cy.get('[data-cy=r0-Color-input]')
+                .should("exist")    
+            cy.get('[data-cy=r0-Count-input]')
                 .should("exist")
-            cy.get('[data-cy=r0-regex-input]')
+            cy.get('[data-cy=r0-Date-input]')
                 .should("exist")
-            cy.get('[data-cy=r0-date-input]')
-                .should("exist")
-            cy.get('[data-cy=r0-boolean-input]')
+            cy.get('[data-cy=r0-Purchased-input]')
                 .should("exist")
         })
 
@@ -469,7 +471,7 @@ describe('custom table component', () => {
             cy.get('[data-cy=r0-edit-button]')
                 .click()
 
-            cy.get('[data-cy=r0-text-input]')
+            cy.get('[data-cy=r0-Item-input]')
                 .clear()
                 .type('Testing')
 
@@ -484,7 +486,7 @@ describe('custom table component', () => {
             cy.get('[data-cy=r0-edit-button]')
                 .click()
             
-            cy.get('[data-cy=r0-dropdown-input]')
+            cy.get('[data-cy=r0-Color-input]')
                 .select('Black')
             
             cy.get('[data-cy=r0-save-button]')
@@ -499,7 +501,7 @@ describe('custom table component', () => {
             cy.get('[data-cy=r0-edit-button]')
                 .click()
 
-            cy.get('[data-cy=r0-regex-input] > [data-cy=text-input]')
+            cy.get('[data-cy=r0-Count-input] > [data-cy=text-input]')
                 .clear()
                 .type('12.5')
                 .blur()
@@ -507,7 +509,7 @@ describe('custom table component', () => {
             cy.get('[data-cy=r0-save-button]')
                 .should("be.disabled")
 
-            cy.get('[data-cy=r0-regex-input] > [data-cy=text-input]')
+            cy.get('[data-cy=r0-Count-input] > [data-cy=text-input]')
                 .clear()
                 .type('2')
                 .blur()
@@ -523,7 +525,7 @@ describe('custom table component', () => {
             cy.get('[data-cy=r0-edit-button]')
                 .click()
 
-            cy.get('[data-cy=r0-date-input]')
+            cy.get('[data-cy=r0-Date-input]')
                 .type('2020-05-14')
 
             cy.get('[data-cy=r0-save-button]')
@@ -534,20 +536,20 @@ describe('custom table component', () => {
         })
 
         it('allows you to check and uncheck only while editing', () => {
-            cy.get('[data-cy=r0-boolean-input]')
+            cy.get('[data-cy=r0-Purchased-input]')
                 .should('be.disabled')
 
             cy.get('[data-cy=r0-edit-button]')
                 .click()
 
-            cy.get('[data-cy=r0-boolean-input]')
+            cy.get('[data-cy=r0-Purchased-input]')
                 .should('be.enabled')
                 .uncheck()
 
             cy.get('[data-cy=r0-save-button]')
                 .click()
 
-            cy.get('[data-cy=r0-boolean-input')
+            cy.get('[data-cy=r0-Purchased-input')
                 .should('not.be.checked')
         })
     })


### PR DESCRIPTION
__Pull Request Description__

The CustomTableComponent `data-cy` attributes for input elements did not uniquely identify the input element.  In particular, if two elements had the same type of input they would have had the same `data-cy` attribute value.  They now have the value `ri-columnHeader-input` where the `columnHeader` is the header of their column in the table.  This matches what is done for cells when the table is not in edit mode.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
