### PR TITLE
Added the pageLoaded pattern to barnKit and fieldKit

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
@@ -77,6 +77,7 @@
                 </div> 
             </div>
         </div>
+        <div data-cy="page-loaded" v-show=false>{{ pageLoaded }}</div>
     </div>
     <script>
         var seedingReport = new Vue ({
@@ -113,6 +114,8 @@
                 errBannerVisibility: false,
 
                 isMobile: false,
+
+                createdCount: 0,
             },
             methods: {
                 hide(){
@@ -816,12 +819,17 @@
                     {"header": 'Comments', "visible": true, "inputType" : {'type': 'text'}},
                     {"header": 'User', "visible": true, "inputType" : {'type': 'dropdown', 'value': this.userNameArray}},
                     ]
-                }
+                },
+                pageLoaded() {
+                    // Check here that the correct number of API calls have completed.
+                    return this.createdCount == 8
+                },
             },
             created() {
                 getSessionToken()
                     .then((response) => {
                         this.sessionToken = response
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -829,6 +837,7 @@
                 getIDToCropMap()
                     .then((response) => {
                         this.idToCropMap = new Map(response)
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -840,6 +849,7 @@
                         for(let [key, info] of this.cropToIDMap){
                             this.cropNameArray.push(key)
                         }
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -847,6 +857,7 @@
                 getIDToUserMap()
                     .then((response) => {
                         this.idToUserMap = new Map (response)
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -854,6 +865,7 @@
                 getUserToIDMap()
                     .then((response) => {
                         this.userToIDMap = new Map (response)
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -861,6 +873,7 @@
                 getAreaToIDMap()
                     .then((response) => {
                         this.areaToIDMap = new Map(response)
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -868,6 +881,7 @@
                 getUnitToIDMap()
                     .then((response) => {
                         this.unitToIDMap = new Map(response)
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -879,10 +893,12 @@
                             this.tableColumns[10].visible = false
                             this.tableColumns[11].visible = false
                         }
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
                     })
+
                 if (window.screen.width < 900 || window.screen.height < 900) {
                     this.isMobile = true
                 }

--- a/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.spec.js
@@ -23,47 +23,10 @@ describe('Testing for the seeding report page', () => {
 
     beforeEach(() => {
         cy.login('manager1', 'farmdata2')
-            .then(() => {
-                // Using wrap to wait for the asynchronus API request.
-                cy.wrap(getCropToIDMap()).as('cropMap')
-                cy.wrap(getAreaToIDMap()).as('areaMap')
-                cy.wrap(getIDToCropMap()).as('IDCropMap')
-                cy.wrap(getUserToIDMap()).as('userMap')
-                cy.wrap(getUnitToIDMap()).as('unitMap')
-                cy.wrap(getSessionToken()).as('token')
-            })
-        // Wait here for the maps in the tests.
-        cy.get('@token').should(function(token) {
-            sessionToken = token
-        })
-        cy.get('@cropMap').should(function(map) {
-            cropToIDMap = map
-        })
-        cy.get('@areaMap').should(function(map) {
-            areaToIDMap = map
-        })
-        cy.get('@IDCropMap').should(function(map) {
-            IDToCropMap = map
-        })
-        cy.get('@userMap').should(function(map) {
-            userToIDMap = map
-        })
-        cy.get('@unitMap').should(function(map) {
-            unitToIDMap = map
-        })
-
-        // Setting up wait for the request in the created() to complete.
-        cy.intercept('GET', 'taxonomy_term?bundle=farm_crops&page=1').as('cropmap')
-        cy.intercept('GET', 'taxonomy_term.json?bundle=farm_areas').as('areamap')
-        cy.intercept('GET', '/taxonomy_term.json?bundle=farm_crops').as('IDCropMap')
-        cy.intercept('GET', 'user').as('userMap')
-        cy.intercept('GET', 'taxonomy_term.json?bundle=farm_quantity_units').as('unitMap')
-
-        // cy.restoreLocalStorage()
         cy.visit('/farm/fd2-barn-kit/seedingReport')
 
         // Wait here for the maps to load in the page.
-        cy.wait(['@cropmap', '@areamap', '@IDCropMap', '@userMap', '@unitMap'])
+        cy.waitForPage()
     })
 
     context('can set dates and then render the report', () => {

--- a/farmdata2/farmdata2_modules/fd2_barn_kit/transplantingReport/transplantingReport.html
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/transplantingReport/transplantingReport.html
@@ -61,6 +61,7 @@
                 </div> 
             </div>
         </div>
+        <div data-cy="page-loaded" v-show=false>{{ pageLoaded }}</div>
     </div>
     <script>
         var transplantingReport = new Vue ({
@@ -94,6 +95,8 @@
 
                 rowBeingEdited: false,
                 errBannerVisibility: false,
+
+                createdCount: 0, 
             },
             methods: {
                 hide(){
@@ -535,12 +538,17 @@
                     {"header": 'Comments', "visible": true, "inputType" : {'type': 'text'}},
                     {"header": 'User', "visible": true, "inputType" : {'type': 'dropdown', 'value': this.userNameArray}},
                 ]
-                }
+                },
+                pageLoaded() {
+                    // Check here that the correct number of API calls have completed.
+                    return this.createdCount == 8
+                },
             },
             created() {
                 getSessionToken()
                     .then((response) => {
                         this.sessionToken = response
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -548,6 +556,7 @@
                 getIDToCropMap()
                     .then((response) => {
                         this.idToCropMap = new Map(response)
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -555,6 +564,7 @@
                 getCropToIDMap()
                     .then((response) => {
                         this.cropToIDMap = new Map(response)
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -562,6 +572,7 @@
                 getIDToUserMap()
                     .then((response) => {
                         this.idToUserMap = new Map (response)
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -569,6 +580,7 @@
                 getUserToIDMap()
                     .then((response) => {
                         this.userToIDMap = new Map (response)
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -576,6 +588,7 @@
                 getAreaToIDMap()
                     .then((response) => {
                         this.areaToIDMap = new Map(response)
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -583,6 +596,7 @@
                 getUnitToIDMap()
                     .then((response) => {
                         this.unitToIDMap = new Map(response)
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -594,6 +608,7 @@
                             this.visibleColumns[7] = false
                             this.visibleColumns[8] = false
                         }
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true

--- a/farmdata2/farmdata2_modules/fd2_barn_kit/transplantingReport/transplantingReport.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/transplantingReport/transplantingReport.spec.js
@@ -22,43 +22,10 @@ describe('Testing for the transplanting report page', () => {
 
     beforeEach(() => {
         cy.login('manager1', 'farmdata2')
-            .then(() => {
-                // Using wrap to wait for the asynchronus API request.
-                cy.wrap(getCropToIDMap()).as('cropMap')
-                cy.wrap(getAreaToIDMap()).as('areaMap')
-                cy.wrap(getIDToCropMap()).as('IDCropMap')
-                cy.wrap(getUserToIDMap()).as('userMap')
-                cy.wrap(getUnitToIDMap()).as('unitMap')
-            })
-        // Wait here for the maps in the tests.
-        cy.get('@cropMap').should(function(map) {
-            cropToIDMap = map
-        })
-        cy.get('@areaMap').should(function(map) {
-            areaToIDMap = map
-        })
-        cy.get('@IDCropMap').should(function(map) {
-            IDToCropMap = map
-        })
-        cy.get('@userMap').should(function(map) {
-            userToIDMap = map
-        })
-        cy.get('@unitMap').should(function(map) {
-            unitToIDMap = map
-        })
-        
-        // Setting up wait for the request in the created() to complete.
-        cy.intercept('GET', 'taxonomy_term?bundle=farm_crops&page=1').as('cropmap')
-        cy.intercept('GET', 'taxonomy_term.json?bundle=farm_areas').as('areamap') 
-        cy.intercept('GET', '/taxonomy_term.json?bundle=farm_crops').as('IDCropMap')
-        cy.intercept('GET', 'user').as('userMap') 
-        cy.intercept('GET', 'taxonomy_term.json?bundle=farm_quantity_units').as('unitMap') 
-        
-        // cy.restoreLocalStorage()
         cy.visit('/farm/fd2-barn-kit/transplantingReport')
     
         // Wait here for the maps to load in the page.   
-        cy.wait(['@cropmap', '@areamap', '@IDCropMap', '@userMap', '@unitMap'])
+        cy.waitForPage()
     })
 
     context('can set dates and then render the report', () => {

--- a/farmdata2/farmdata2_modules/fd2_example/cache/cache.html
+++ b/farmdata2/farmdata2_modules/fd2_example/cache/cache.html
@@ -14,6 +14,8 @@
         <!-- Give each LI a data-cy attribute that matches the list numbering -->
         <LI v-for="(crop,i) in cropNames"><span :data-cy=(i+1)+'crop'>{{ crop }}</span></LI>
     </OL>
+
+    <div data-cy="page-loaded" v-show=false>{{ pageLoaded }}</div>
 </div>
 
 <script>
@@ -26,7 +28,7 @@ new Vue({
         userName: fd2UserName,
 
         cropsResponse: null,
-        
+        createdCount: 0, 
     },
     methods: {
         clearCache() {
@@ -43,12 +45,18 @@ new Vue({
                 return this.cropsResponse.map((h) => h.name)
             }
         },
+        pageLoaded() {
+            // Check here that the correct number of API calls have completed.
+            return this.createdCount == 2
+        },
     },
     created() {
         // If the value we are looking for is in the cache, then use it as is to start.
         if(localStorage.getItem('crops') != null) {
             // Need to JSON.parse it because it was stringified when we put it in there.
             this.cropsResponse = JSON.parse(localStorage.getItem('crops'))
+
+            this.createdCount++
         }
         
         // Whether we found the value in the cache or not we now want to request it again.
@@ -61,6 +69,8 @@ new Vue({
         getAllPages('/taxonomy_term.json?bundle=farm_crops',response).then(() => {
             localStorage.setItem('crops', JSON.stringify(response))
             this.cropsResponse = response
+
+            this.createdCount++
         })
     }
 })

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.html
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.html
@@ -78,6 +78,8 @@
         <div style='text-align:center;'>
             <label style='color: #da4f3f'>* required field.</label>
         </div> 
+
+        <div data-cy="page-loaded" v-show=false>{{ pageLoaded }}</div>
     </div>
     
     <script>
@@ -135,6 +137,8 @@
                 regNumWorker: regexMap.regPosInt,
                 errBannerVisibility: false,
                 configToIDMap: new Map(),
+
+                createdCount: 0, 
             },
             methods:{
                 updateValidMap(key, bool) {    
@@ -521,6 +525,10 @@
                     ]
                     return quantity 
                 },
+                pageLoaded() {
+                    // Check here that the correct number of API calls have completed.
+                    return this.createdCount == 9
+                },
             },
             created(){
                 let fullResponse = []
@@ -529,6 +537,7 @@
                         .then(() => {
                             this.cropArray = fullResponse.map((h) => h.name)
                             localStorage.setItem('crops', JSON.stringify(this.cropArray))
+                            this.createdCount++
                         })
                         .catch((err) => { 
                             this.errBannerVisibility = true
@@ -539,6 +548,7 @@
                         .then(() => {
                             this.cropArray = fullResponse.map((h) => h.name)
                             localStorage.setItem('crops', JSON.stringify(this.cropArray))
+                            this.createdCount++
                         })
                         .catch((err) => { 
                             this.errBannerVisibility = true
@@ -548,6 +558,7 @@
                     getAllPages('/taxonomy_term.json?bundle=farm_areas', this.areaResponse)
                         .then(() => {
                             localStorage.setItem('areas', JSON.stringify(this.areaResponse))
+                            this.createdCount++
                         })
                         .catch((err) => { 
                             this.errBannerVisibility = true
@@ -558,6 +569,7 @@
                         .then((resp) => {
                             this.areaResponse = resp
                             localStorage.setItem('areas', JSON.stringify(resp))
+                            this.createdCount++
                         })
                         .catch((err) => { 
                             this.errBannerVisibility = true
@@ -566,6 +578,7 @@
                 getSessionToken()
                     .then((response) => {
                         this.sessionToken = response
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -573,6 +586,7 @@
                 getCropToIDMap()
                     .then((response) => {
                         this.cropToIDMap = response
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -580,6 +594,7 @@
                 getUserToIDMap()
                     .then((response) => {
                         this.userToIDMap = response
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -587,6 +602,7 @@
                 getAreaToIDMap()
                     .then((response) => {
                         this.areaToIDMap = response
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -594,6 +610,7 @@
                 getUnitToIDMap()
                     .then((response) => {
                         this.unitToIDMap = response
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -601,6 +618,7 @@
                 getLogTypeToIDMap()
                     .then((response) => {
                         this.logTypeToIDMap = response
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true
@@ -613,6 +631,7 @@
                             this.regMin = "|" + regexMap.regPosInt
                             this.regHour = "|" + regexMap.regPosFloatTwoDigit
                         }
+                        this.createdCount++
                     })
                     .catch((err) => { 
                         this.errBannerVisibility = true


### PR DESCRIPTION
__Pull Request Description__

The pageLoaded pattern has been applied to the barnKit and fieldKit pages.  This pattern places a hidden element in the page that has its value set to true when all of the API calls in the `created` method have completed. This is used in testing to ensure that the page has fully loaded before the tests are run. 

This is important because when pages are loading information in the `created` method, fast running tests were completing and the next test was starting before those API requests had completed or even been initiated.  This was generating flakiness in the test suite.  It would run fine one time and not the next.  Waiting for the page to load introduces delays, but removes the flakiness.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
