### PR TITLE
Surpressing Standard Name Error

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_barn_kit/fd2_barn_kit.module
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/fd2_barn_kit.module
@@ -97,6 +97,7 @@ function fd2_barn_kit_preprocess_page() {
     drupal_add_js('https://unpkg.com/dayjs@1.8.21/dayjs.min.js', 'external');
 
     // Define some useful variables in the JavaScript for page.
+    // the @ symbol surpresses the warning when a user attempts to access a page without being logged in
     global $user;
     @$cmd="var fd2UserID=".$user->uid."; var fd2UserName='".$user->name."';";
     drupal_add_js($cmd,'inline');

--- a/farmdata2/farmdata2_modules/fd2_barn_kit/fd2_barn_kit.module
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/fd2_barn_kit.module
@@ -98,7 +98,7 @@ function fd2_barn_kit_preprocess_page() {
 
     // Define some useful variables in the JavaScript for page.
     global $user;
-    $cmd="var fd2UserID=".$user->uid."; var fd2UserName='".$user->name."';";
+    @$cmd="var fd2UserID=".$user->uid."; var fd2UserName='".$user->name."';";
     drupal_add_js($cmd,'inline');
   }
 };

--- a/farmdata2/farmdata2_modules/fd2_config/fd2_config.module
+++ b/farmdata2/farmdata2_modules/fd2_config/fd2_config.module
@@ -114,25 +114,26 @@ function fd2_config_menu() {
 
 // This function Loads the content for the sub-tab from the html file specified in the argument.
 function fd2_config_view($subtab_content) {
- $dir=dirname(__FILE__);
- $html=$dir."/".$subtab_content."/".$subtab_content.".html";
- $code=file_get_contents($html);
- return $code;
+  $dir=dirname(__FILE__);
+  $html=$dir."/".$subtab_content."/".$subtab_content.".html";
+  $code=file_get_contents($html);
+  return $code;
 };
 
 function fd2_config_preprocess_page() {
- $alias = drupal_get_path_alias(current_path());
- $path = implode("\n",array('farm/fd2-config*',));
+  $alias = drupal_get_path_alias(current_path());
+  $path = implode("\n",array('farm/fd2-config*',));
 
- if (drupal_match_path($alias, $path)) {
-   // Include the external JS libraries that are used here so they are cached by drupal.
-   drupal_add_js('https://unpkg.com/vue@2.6.14/dist/vue.min.js','external');
-   drupal_add_js('https://unpkg.com/axios@0.24.0/dist/axios.min.js','external');
-   drupal_add_js('https://unpkg.com/dayjs@1.8.21/dayjs.min.js', 'external');
+  if (drupal_match_path($alias, $path)) {
+    // Include the external JS libraries that are used here so they are cached by drupal.
+    drupal_add_js('https://unpkg.com/vue@2.6.14/dist/vue.min.js','external');
+    drupal_add_js('https://unpkg.com/axios@0.24.0/dist/axios.min.js','external');
+    drupal_add_js('https://unpkg.com/dayjs@1.8.21/dayjs.min.js', 'external');
 
-   // Define some useful variables in the JavaScript for page.
-   global $user;
-   $cmd="var fd2UserID=".$user->uid."; var fd2UserName='".$user->name."';";
-   drupal_add_js($cmd,'inline');
- }
+    // Define some useful variables in the JavaScript for page.
+    // the @ symbol surpresses the warning when a user attempts to access a page without being logged in
+    global $user;
+    @$cmd="var fd2UserID=".$user->uid."; var fd2UserName='".$user->name."';";
+    drupal_add_js($cmd,'inline');
+  }
 };

--- a/farmdata2/farmdata2_modules/fd2_config/fd2_config.module
+++ b/farmdata2/farmdata2_modules/fd2_config/fd2_config.module
@@ -97,19 +97,19 @@ function fd2_config_entity_property_info() {
 * menu at the top of the FarmData2 page with the Dashboard.
 */
 function fd2_config_menu() {
- $items = array();
+  $items = array();
 
- // Define the tab for the module.
- $items['farm/fd2-config'] = array(
-   'title' => 'FD2 Config',
-   'page callback' => 'fd2_config_view',
-   'page arguments' => array('config'),
-   'access arguments' => array('view fd2 config'),
-   'type' => MENU_LOCAL_TASK,
-   'weight' => 300,
- );
+  // Define the tab for the module.
+  $items['farm/fd2-config'] = array(
+    'title' => 'FD2 Config',
+    'page callback' => 'fd2_config_view',
+    'page arguments' => array('config'),
+    'access arguments' => array('view fd2 config'),
+    'type' => MENU_LOCAL_TASK,
+    'weight' => 300,
+  );
 
- return $items;
+  return $items;
 };
 
 // This function Loads the content for the sub-tab from the html file specified in the argument.

--- a/farmdata2/farmdata2_modules/fd2_example/fd2_example.module
+++ b/farmdata2/farmdata2_modules/fd2_example/fd2_example.module
@@ -5,37 +5,37 @@
  * See the README.md file in the fd2_example directory for more information.
  */
 
- function fd2_example_permission() {
-   return array(
-     'view fd2 example' => array(
-       'title' => t('View FD2 Example'),
-     ),
-     'configure fd2 Example' => array(
-       'title' => t('Configure FD2 Example'),
-     ),
-   );
- }
+function fd2_example_permission() {
+  return array(
+    'view fd2 example' => array(
+        'title' => t('View FD2 Example'),
+    ),
+    'configure fd2 Example' => array(
+        'title' => t('Configure FD2 Example'),
+    ),
+  );
+}
 
- function fd2_example_farm_access_perms($role) {
-   $perms = array();
+function fd2_example_farm_access_perms($role) {
+  $perms = array();
 
    // Load the list of farm roles.
-   $roles = farm_access_roles();
+  $roles = farm_access_roles();
 
    // If this role has 'edit' access, allow them to see the Example tab.
-   if (!empty($roles[$role]['access']['edit'])) {
-     $perms[] = 'view fd2 example';
-   }
+  if (!empty($roles[$role]['access']['edit'])) {
+    $perms[] = 'view fd2 example';
+  }
 
    // If this role has 'config' access, it to configure the fd2_example module.
-   if (!empty($roles[$role]['access']['config'])) {
-     $perms[] = 'configure fd2 example';
-   }
+  if (!empty($roles[$role]['access']['config'])) {
+    $perms[] = 'configure fd2 example';
+  }
 
-   return $perms;
- }
+  return $perms;
+}
 
- /**
+/**
  * Implements hook_menu() which places the Exmple tab in the Farm
  * menu at the top of the FarmData2 page with the Dashboard.
  */
@@ -131,8 +131,9 @@ function fd2_example_preprocess_page() {
     drupal_add_js('https://unpkg.com/dayjs@1.8.21/dayjs.min.js', 'external');
 
     // Define some useful variables in the JavaScript for page.
+    // the @ symbol surpresses the warning when a user attempts to access a page without being logged in
     global $user;
-    $cmd="var fd2UserID=".$user->uid."; var fd2UserName='".$user->name."';";
+    @$cmd="var fd2UserID=".$user->uid."; var fd2UserName='".$user->name."';";
     drupal_add_js($cmd,'inline');
   }
 };

--- a/farmdata2/farmdata2_modules/fd2_field_kit/fd2_field_kit.module
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/fd2_field_kit.module
@@ -88,6 +88,7 @@ function fd2_field_kit_preprocess_page() {
     drupal_add_js('https://unpkg.com/dayjs@1.8.21/dayjs.min.js', 'external');
 
     // Define some useful variables in the JavaScript for page.
+    // the @ symbol surpresses the warning when a user attempts to access a page without being logged in
     global $user;
     @$cmd="var fd2UserID=".$user->uid."; var fd2UserName='".$user->name."';";
     drupal_add_js($cmd,'inline');

--- a/farmdata2/farmdata2_modules/fd2_field_kit/fd2_field_kit.module
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/fd2_field_kit.module
@@ -89,7 +89,7 @@ function fd2_field_kit_preprocess_page() {
 
     // Define some useful variables in the JavaScript for page.
     global $user;
-    $cmd="var fd2UserID=".$user->uid."; var fd2UserName='".$user->name."';";
+    @$cmd="var fd2UserID=".$user->uid."; var fd2UserName='".$user->name."';";
     drupal_add_js($cmd,'inline');
   }
 };

--- a/farmdata2/farmdata2_modules/fd2_school/fd2_school.module
+++ b/farmdata2/farmdata2_modules/fd2_school/fd2_school.module
@@ -86,7 +86,7 @@ function fd2_school_preprocess_page() {
 
     // Define some useful variables in the JavaScript for page.
     global $user;
-    $cmd="var fd2UserID=".$user->uid."; var fd2UserName='".$user->name."';";
+    @$cmd="var fd2UserID=".$user->uid."; var fd2UserName='".$user->name."';";
     drupal_add_js($cmd,'inline');
   }
 };

--- a/farmdata2/farmdata2_modules/fd2_school/fd2_school.module
+++ b/farmdata2/farmdata2_modules/fd2_school/fd2_school.module
@@ -85,6 +85,7 @@ function fd2_school_preprocess_page() {
     drupal_add_js('https://unpkg.com/dayjs@1.8.21/dayjs.min.js', 'external');
 
     // Define some useful variables in the JavaScript for page.
+    // the @ symbol surpresses the warning when a user attempts to access a page without being logged in
     global $user;
     @$cmd="var fd2UserID=".$user->uid."; var fd2UserName='".$user->name."';";
     drupal_add_js($cmd,'inline');


### PR DESCRIPTION
__Pull Request Description__

Closes #565. Adds a simple simple `@` in front of the cmd command that maps the user ID's and names as a preprocessing function. This error would appear when users attempted to access a page without being logged into the page. The warning no longer appears due to this surpression and a comment explaining the `@` placement is now present in the module files. 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
