### PR TITLE
1. Changes to transplantingReport.html

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_barn_kit/transplantingReport/transplantingReport.html
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/transplantingReport/transplantingReport.html
@@ -80,6 +80,7 @@
                 reportVisible: false,
                 transplantingLogs: [],
                 updateLog: [],
+                fieldAreas: [],
 
                 sessionToken: null,
                 selectedCrop: 'All',
@@ -504,15 +505,6 @@
                     return userNameArray
                 },
 
-                areaNameArray(){
-                    let areaNameArray = []
-                    const areaKeyIterator = this.areaToIDMap.keys()
-                    for(i = 0; i < this.areaToIDMap.size; i++){
-                        areaNameArray.push(areaKeyIterator.next().value)
-                    }
-                    return areaNameArray
-                },
-
                 cropNameArray(){
                     let cropNameArray = []
                     for(let [key, info] of this.cropToIDMap){
@@ -528,7 +520,7 @@
                     return [
                     {"header": 'Date', "visible": true, "inputType" : {'type': 'date'}}, 
                     {"header": 'Crop', "visible": true, "inputType" : {'type': 'dropdown', value: this.cropNameArray}}, 
-                    {"header": 'Area', "visible": true, "inputType" : {'type': 'dropdown', value: this.areaNameArray}}, 
+                    {"header": 'Area', "visible": true, "inputType" : {'type': 'dropdown', value: this.fieldAreas}}, 
                     {"header": 'Row Feet', "visible": true, "inputType" : {'type': 'regex', 'regex': '^[1-9]+[0-9]*$'}},
                     {"header": 'Bed Feet', "visible": true, "inputType" : {'type': 'no input'}},
                     {"header": 'Rows/Bed', "visible": true, "inputType" : {'type': 'regex', 'regex': '^[1-9]+[0-9]*$'}},
@@ -541,10 +533,41 @@
                 },
                 pageLoaded() {
                     // Check here that the correct number of API calls have completed.
-                    return this.createdCount == 8
+                    return this.createdCount == 9
                 },
             },
             created() {
+                let areaResponse = []
+                if(localStorage.getItem('areas') == null){
+                    getAllPages('/taxonomy_term.json?bundle=farm_areas', this.areaResponse)
+                        .then(() => {
+                            localStorage.setItem('areas', JSON.stringify(this.areaResponse))
+
+                            this.fieldAreas = this.areaResponse.filter((x) => x.area_type === 'field' || x.area_type === 'bed')
+                            this.fieldAreas = (this.fieldAreas).map((h) => h.name)
+
+                            this.createdCount++
+                        })
+                        .catch((err) => { 
+                            this.errBannerVisibility = true
+                        })
+                }
+                else{
+                    this.areaResponse = JSON.parse(localStorage.getItem('areas'))
+                    getAllPages('/taxonomy_term.json?bundle=farm_areas')
+                        .then((resp) => {
+                            this.areaResponse = resp
+                            localStorage.setItem('areas', JSON.stringify(resp))
+
+                            this.fieldAreas = this.areaResponse.filter((x) => x.area_type === 'field' || x.area_type === 'bed')
+                            this.fieldAreas = (this.fieldAreas).map((h) => h.name)
+                            
+                            this.createdCount++
+                        })
+                        .catch((err) => { 
+                            this.errBannerVisibility = true
+                        })
+                }
                 getSessionToken()
                     .then((response) => {
                         this.sessionToken = response


### PR DESCRIPTION
__Pull Request Description__

Closes #632. This PR aims to remove the user's ability to assign the incorrect area to transplanting logs when they're being edited. Transplanting logs are tray seedings that are move from a greenhouse area to a field area. So, users shouldn't be permitted to edit the log's area back to a greenhouse area. This PR accomplishes that by removing greenhouse areas from the options. 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
