### PR TITLE
Add Bootstrap support to Vue Component Tests

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -143,7 +143,8 @@ RUN npm install -d \
         @cypress/webpack-dev-server@2.5.0 \
         @cypress/vue2@1.1.2 \
         path@0.12.7 \
-        axios@0.24.0
+        axios@0.24.0 \
+        bootstrap@3.3.7
 WORKDIR /home/$USERNAME
 
 # Configure the VNC server so that it allows fd2dev to connect without

--- a/farmdata2/cypress/support/component.js
+++ b/farmdata2/cypress/support/component.js
@@ -16,6 +16,12 @@
 // Import commands.js using ES2015 syntax:
 import './commands'
 
+// Import specific FD2 style sheet
+import '/home/fd2dev/fd2test/farmdata2/farmdata2_modules/resources/fd2.css'
+
+// Import Bootstrap style sheet
+import 'bootstrap/dist/css/bootstrap.css'
+
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 


### PR DESCRIPTION
__Pull Request Description__

Imported stylesheets to the `component.js` file so that the `CustomTableComponent` and the `BannerComponent` appear as they are supposed to within the unit tests.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
