### PR TITLE
Migrates: FieldKit Tab: Test for FieldKit Sub-Tabs  (#212)

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_field_kit/cypress/fieldkit.tab.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/cypress/fieldkit.tab.spec.js
@@ -1,0 +1,42 @@
+/**
+ * This file contains Cypress tests for the FieldKit tabbed interface on the fd2_farmdata2 website.
+ * The tests check the following:
+ *
+ * - The FieldKit tab contains sub-tabs for "Info" and "Seeding Input."
+ * - The order of the tabs is "Info" and then "Seeding Input."
+ * - There are the correct number of sub-tabs (2 at this time).
+ *
+ * These tests are intended to ensure that the FieldKit tabbed interface is implemented correctly
+ * and that it meets the requirements specified by the design.
+ */
+
+describe('Test for FieldKit Sub-Tabs', () => {
+
+  beforeEach(() => {
+    cy.login('manager1', 'farmdata2')
+    cy.visit('/farm/fd2-field-kit')
+  })
+
+  //issue #200, sub-task 1
+  it('Verify that FieldKit tab contains sub-tabs for "Info" and "Seeding Input"', () => {
+    cy.get('.pagination-sm').contains('Info').should('exist')
+    cy.get('.pagination-sm').contains('Seeding Input').should('exist')
+  })
+
+  //issue #200, sub-task 2
+  it('checks the order of the tabs is “Info” and then “Seeding Input.”', () => {
+    cy.get('ul.pagination-sm')
+      .find('li')
+      .filter(':contains("Info")')
+      .next()
+      .should('contain', 'Seeding Input');
+  })
+
+  //issue #200, sub-task 3
+  it('checks the correct number of sub-tabs', () => {
+    cy.get('ul.pagination-sm')
+      .find('li')
+      .should('have.length', 2)
+  })
+
+})


### PR DESCRIPTION
* Created txt file for initialize branch

* Created epr1.md

* deleted created_branch.txt

* Revised EPR1

* cypress file created for fieldkit sub-tab

* beforeEach added for login in farmdata2 web

* changed url for beforeEach and sub-task1 finished

* finished sub-task 1

* Checks that the order of the tabs is “Info” and then “Seeding Input.”

* ignore this commit

* Revert "deleted created_branch.txt"

This reverts commit fff6611033b011469f6543c3964db1433d084306.

* Implemented a test that checks the correct number of sub-tabs

* Removed create_branch.txt and reports directory.

* Verifies that the number of sub- tabs is exactly 2 and adds a general comment at the top of the file

Co-authored-by: won369369 <wj0293@gmail.com>
Co-authored-by: Shahir-47 <ahmeds@dickinson.edu>

---------

__Pull Request Description__

This pull request was orignially created on [FD2School-FarmData2](https://github.com/DickinsonCollege/FD2School-FarmData2).
Link to the original pull request: https://github.com/DickinsonCollege/FD2School-FarmData2/pull/212

Partially Addresses https://github.com/DickinsonCollege/FarmData2/issues/662

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
