### PR TITLE
Migrates: Testing Seeding Input Tray Seeding Defaults (#194)

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.html
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.html
@@ -27,7 +27,7 @@
             <div v-show='(selectedSeedingType=="")' style='text-align:center;font-size: medium;'>
                 <p>Please Select Tray Seeding or Direct Seeding<label style='color: #da4f3f'>*</label></p>
             </div>
-            <div v-show='(selectedSeedingType=="Tray Seedings")' style='padding: 12px; text-align:center; font-size: medium; margin-top: 45px;'> 
+            <div data-cy="tray-selection" v-show='(selectedSeedingType=="Tray Seedings")' style='padding: 12px; text-align:center; font-size: medium; margin-top: 45px;'> 
                 <dropdown-with-all data-cy="tray-area-selection" :selected-val='selectedArea' :dropdown-list='areaFilter' @selection-changed='setNewArea' style='width: 125px;' :disabled='submitInProgress'>Area:<label style='color: #da4f3f'>*</label></dropdown-with-all>
                 <br>
                 <label>Cells/Tray:<label style='color: #da4f3f'>*</label>

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.tray.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.tray.defaults.spec.js
@@ -1,0 +1,52 @@
+describe('Test the tray seeding ', () => {
+    beforeEach(() => {
+        cy.login("manager1", "farmdata2")
+        cy.visit('/farm/fd2-field-kit/seedingInput')
+       })
+
+    it("Check the tray seeding section when 'Tray' is selected ", () => {
+        cy.get ("[data-cy=tray-seedings]").check()
+        cy.get("[data-cy=tray-selection]").should("be.visible")})
+
+    it("Check the dropdown Area ", () => {
+        cy.get ("[data-cy=tray-seedings]").check()
+        cy.get("[data-cy=tray-area-selection]>[data-cy=dropdown-input]").should("be.visible")
+        cy.get("[data-cy=tray-area-selection]>[data-cy=dropdown-input]").should("not.be.disabled")
+        cy.get("[data-cy=tray-area-selection]>[data-cy=dropdown-input]").should("have.value",null)
+    })
+
+    it("Test area dropdown", () => {
+        cy.get("[data-cy=tray-seedings]").check()
+        cy.get("[data-cy=tray-area-selection] > [data-cy=dropdown-input] > [data-cy=option0")
+        .should("have.value", "CHUAU")
+        cy.get("[data-cy=tray-area-selection] > [data-cy=dropdown-input] > [data-cy=option2")
+        .should("have.value", "JASMINE")
+        cy.get("[data-cy=tray-area-selection] > [data-cy=dropdown-input] > [data-cy=option4")
+        .should("have.value", "SEEDING BENCH")
+    })
+
+    it("Test cells/tray field", () => {
+        cy.get("[data-cy=tray-seedings]").check()
+        cy.get("[data-cy=num-cell-input]")
+        .should("be.visible")
+        cy.get("[data-cy=num-cell-input] > [data-cy=text-input]")
+        .should("not.be.disabled")
+        .should("be.empty")
+    })
+
+    it("Check tray field", () => {
+        cy.get("[data-cy=num-tray-input]").should("not.visible");
+        cy.get("[data-cy=tray-seedings]").click();
+        cy.get("[data-cy=num-tray-input] > [data-cy=text-input]").should("be.visible")
+                                        .should("not.be.disabled")
+                                        .should("have.value","")
+    });
+
+    it("Check seed field", () => {
+        cy.get("[data-cy=num-seed-input] ").should("not.be.visible");
+        cy.get("[data-cy=tray-seedings]").click();
+        cy.get("[data-cy=num-seed-input] > [data-cy=text-input]").should("be.visible")
+                                        .should("not.be.disabled")
+                                        .should("have.value", "")
+    });
+})


### PR DESCRIPTION
* add tray selection test

* add area dropdown test

* Adding test for seeding field and trays field

* Write tests for area dropdown and cells/tray field in Tray Seeding Input

* reformat the tests and add test no area is selected by default

* Fixing test for input value

* fix testing on tray seeding input

* reformat the test and modify the test dropdown area

* Reformat Testing tray and seed fields

* add blank line and test enable

Co-authored-by: nguyenbanhducA1K51 <ducnguyen.wings@gmail.com>
Co-authored-by: phong260702 <phongdangquoc123@gmail.com>

---------

__Pull Request Description__

This pull request was originally created on [FD2School-FarmData2](https://github.com/DickinsonCollege/FD2School-FarmData2).
Link to the original pull request: https://github.com/DickinsonCollege/FD2School-FarmData2/pull/194

Partially Addresses https://github.com/DickinsonCollege/FarmData2/issues/662

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
