### PR TITLE
Migrates: BarnKit Subtab testing (#219)

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_barn_kit/cypress/barnkitTab.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/cypress/barnkitTab.spec.js
@@ -1,0 +1,22 @@
+describe("Testing SubTabs in BarnKit", () => {
+    beforeEach(() => {
+        cy.login('manager1', 'farmdata2')
+        cy.visit('/farm/fd2-barn-kit')
+    })
+
+    it("BarnKit tab contains the subtabs" , () => {
+        cy.get(".pagination-sm").contains("Info").should("exist")
+        cy.get(".pagination-sm").contains("Seeding Report").should("exist")
+        cy.get(".pagination-sm").contains("Transplanting Report").should("exist")
+    }) 
+
+    it("BarnKit tabs are ordered properly" , () => {
+        cy.get(".pagination-sm > li > a").eq(0).should("contain.text", "Info")
+        cy.get(".pagination-sm > li > a").eq(1).should("contain.text", "Seeding Report")
+        cy.get(".pagination-sm > li > a").eq(2).should("contain.text", "Transplanting Report")
+    }) 
+
+    it("BarnKit has three sub tabs" , () => {
+        cy.get(".pagination-sm > li").should("have.length", "3") 
+    }) 
+})


### PR DESCRIPTION
* Initial commit for BarnKit tab testing

* Tested the BarnKit tab contains the 3 sub-tabs

* Added the Second test and initiated the third test of the barnkitTab.spec.js

* Testing on proper branch

* Revised test for BarnKit subtabs ordering and length

* Delete transplantingReport.defaults.spec.js



* Revised the test for checking number of subtabs

* Resolved issues and committed final changes

Signed-off-by: Udval Enkhtaivan <74579865+udvale@users.noreply.github.com>
Co-authored-by: thorpIV <thorpg@dickinson.edu>
Co-authored-by: aliouas <aliouas@dickinson.edu>

---------

__Pull Request Description__

This pull request was orignially created on [FD2School-FarmData2](https://github.com/DickinsonCollege/FD2School-FarmData2).
Link to the original pull request: https://github.com/DickinsonCollege/FD2School-FarmData2/pull/219

Partially Addresses https://github.com/DickinsonCollege/FarmData2/issues/662

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
