### PR TITLE
Migrates: Test Seeding Input Direct Seeding Defaults (#182)

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.direct.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.direct.defaults.spec.js
@@ -1,0 +1,75 @@
+/*
+This file contains tests for the seeding input functionality in the FarmData2 Field Kit application.
+The purpose of these tests is to verify the proper functioning of the seeding input form elements,
+such as display, loading of area data, field states, and default values.
+*/
+
+describe("Tests for seeding input", () => {
+
+  beforeEach(() => {
+    cy.login('manager1', 'farmdata2')
+    cy.visit('/farm/fd2-field-kit/seedingInput')
+  })
+
+  it('should display the Direct Seeding section when Direct is selected', () => {
+    cy.get('[data-cy=direct-seedings]').check();
+    cy.get('[data-cy=direct-area-selection]').should('be.visible');
+    cy.get('[data-cy=num-rowbed-input]').should('be.visible');
+    cy.get('[data-cy=unit-feet]').should('be.visible');
+    cy.get('[data-cy=num-feet-input]').should('be.visible');
+  });
+
+  it('checks that the area dropdown is enabled', () => {
+    cy.get('[data-cy=direct-seedings]').click()
+    cy.get('[data-cy=direct-area-selection] > [data-cy=dropdown-input]')
+      .should('be.enabled')
+  });
+
+  it('test if areas are correctly loaded to the dropdown for direct seeding', () => {
+    cy.waitForPage()
+    cy.get('[data-cy=direct-seedings]')
+      .click()
+    cy.get('[data-cy=direct-area-selection] > [data-cy=dropdown-input] > [data-cy=option0]')
+      .should('have.value', 'A')
+    cy.get('[data-cy=direct-area-selection] > [data-cy=dropdown-input] > [data-cy=option64]')
+      .should('have.value', 'Z')
+    cy.get('[data-cy=direct-area-selection] > [data-cy=dropdown-input]')
+      .children()
+      .should('have.length', 65)
+  })
+
+  it('checks that there is a field for "Row/Bed" that is empty and enabled', () => {
+    cy.get('[data-cy=direct-seedings]').click()
+    cy.get('[data-cy=num-rowbed-input] > [data-cy=text-input]')
+      .should('be.enabled') // check that it is enabled
+      .should('have.value', '')
+  })
+
+  it('checks that there is a field for "Bed Feed" that is empty and enabled', () => {
+    cy.get('[data-cy=direct-seedings]').click()
+    cy.get('[data-cy=unit-feet] > [data-cy=dropdown-input]')
+      .select('Bed Feet')
+
+    cy.get('[data-cy=num-feet-input] > [data-cy=text-input]')
+      .should('be.enabled') // check that it is enabled
+      .should('have.value', '')
+  })
+
+  it('should display dropdown for units that is enabled', () => {
+    cy.get('[data-cy=direct-seedings]')
+      .click()
+    cy.get('[data-cy=unit-feet] > [data-cy=dropdown-input] > [data-cy=option0]')
+      .should('have.value', 'Bed Feet')
+    cy.get('[data-cy=unit-feet] > [data-cy=dropdown-input] > [data-cy=option1]')
+      .should('have.value', 'Row Feet')
+    cy.get('[data-cy=unit-feet] > [data-cy=dropdown-input]')
+      .children()
+      .should('have.length', 2)
+  })
+
+  it('checks that "Bed Feet" is the default units', () => {
+    cy.get('[data-cy=direct-seedings]').click()
+    cy.get('[data-cy=unit-feet] > [data-cy=dropdown-input]')
+      .should('have.value', 'Bed Feet')
+  })
+})


### PR DESCRIPTION
* Created txt file for initialize branch

* testing commit on feature branch

* SeedingInput cypress file created

* Tests must check that the Direct Seeding section of the Seeding Input Form appears when "Direct" is selected

* deleted create_branch.txt

* cypress test name changed

* Test that it displays dropdown for units

* comment for numbering sub-task 6 added

* test for dropdown area

* Reviewed Gyujin's solution to sub-task 3, 7

* checks that there is a field for Row/Bed that is empty and enabled

* checks that there is a field for Bed Feed that is empty and enabled

* checks that Bed Feet is the default units

* rearranged the order of each sub-test

* changed cypress file name

* changed correct cypress file name

* resolved all conversations from prof. braught

* added comments to each sub-tasks

* changed unit dropdown

* removed then() and added cy.waitForPage() for subtasks 2, 6

* Implemented the test that checks the area dropdown is enabled and removed cy.waitForPage due to error.

* "added cy.waitForPage()"

* Removed sub-task comments

* add a comment at the top of the file describing what the purpose of the file is.

Co-authored-by: won369369 <wj0293@gmail.com>
Co-authored-by: JinLeeGG <leejo@dickinson.edu>
Co-authored-by: Shahir-47 <ahmeds@dickinson.edu>

---------

__Pull Request Description__

This pull request was orignially created on [FD2School-FarmData2](https://github.com/DickinsonCollege/FD2School-FarmData2).
Link to the original pull request: https://github.com/DickinsonCollege/FD2School-FarmData2/pull/182

Partially Addresses https://github.com/DickinsonCollege/FarmData2/issues/662

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
