### PR TITLE
Migrates: Cypress Tests for Seeding Input Labor Defaults (#173)

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.html
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.html
@@ -53,7 +53,7 @@
             </div>
         </fieldset>   
         <fieldset class="panel panel-default center-block" style="max-width: 500px;" v-show="configToIDMap.labor != 'Hidden'">
-            <legend class="panel-heading" style='background-color: #da4f3f; color: white;font-size: x-large;'>Labor</legend>
+            <legend class="panel-heading" style='background-color: #da4f3f; color: white;font-size: x-large;' data-cy="labor-header">Labor</legend>
             <div class="center-block" style='padding: 12px;text-align:center;font-size: medium; margin-top: 45px;'>
                 <label style='color: #da4f3f' v-show="configToIDMap.labor == 'Required'">*&nbsp;</label>
                 <regex-input data-cy='num-worker-input' :reg-exp="regNumWorker" :default-val="numWorkers" set-type="number" set-min="0" :disabled="submitInProgress" @input-changed="setNewNumWorkers" @match-changed="(newBool) => updateValidMap('validNumWorkers', newBool)"></regex-input>                                                

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
@@ -1,0 +1,52 @@
+describe('Test the labor input section', () => {
+
+    beforeEach(() => {
+        cy.login('manager1', 'farmdata2')
+        cy.visit('/farm/fd2-field-kit/seedingInput')
+    }) 
+
+    it("Check header", () => {
+        cy.get("[data-cy='labor-header']")
+            .should("have.text", "Labor")
+    })
+    
+    it("Checks Worker input test", () => {
+        cy.get("[data-cy='num-worker-input'] > [data-cy=text-input]")
+            .should('have.value', '')
+        cy.get("[data-cy='num-worker-input'] > [data-cy=text-input]")
+            .should('have.prop', 'disabled', false)
+    })
+
+    it("Checks Time worked input test", () => {
+        cy.get("[data-cy='minute-input'] > [data-cy=text-input]")
+            .should('have.value', '')
+        cy.get("[data-cy='minute-input'] > [data-cy=text-input]")
+            .should('have.prop', 'disabled', false)
+    })
+
+    it("Checks unit dropdown selection activates correct selected time unit", () => {
+        //check minute-input
+        cy.get("[data-cy='time-unit'] > [data-cy='dropdown-input']")
+            .select("minutes")
+        cy.get("[data-cy='minute-input']").should("be.visible")
+        cy.get("[data-cy='hour-input']").should("not.be.visible")
+
+        //check hour-input
+        cy.get("[data-cy='time-unit'] > [data-cy='dropdown-input']")
+            .select("hours")
+        cy.get("[data-cy='hour-input']").should("be.visible")
+        cy.get("[data-cy='minute-input']").should("not.be.visible")
+    })
+
+    it("Checks Time units dropdown", () => {
+        cy.get("[data-cy='time-unit'] > [data-cy='dropdown-input'] > [data-cy='option0']")
+            .should('have.value', 'minutes')
+        cy.get("[data-cy='time-unit'] > [data-cy='dropdown-input'] > [data-cy='option1']")
+            .should('have.value', 'hours')
+    })
+
+    it("Checks Time units default is minutes", () => {
+        cy.get("[data-cy='time-unit'] > [data-cy='dropdown-input']")
+            .find('option:selected').should("have.text", "minutes")
+    })
+})


### PR DESCRIPTION
* added spec.js file

* Added it block for testing header

* checked the number of workers field is empty and enabled

* checked the number of time worked field is empty and enabled

* Added the "check correct dropdown for selected time unit" "Checks Time units dropdown"
"checks time units default is minutes"

* couple of spacing and alignment issues fixed.



* changed a test name to be more descriptive

Signed-off-by: Foogabob <80643562+Foogabob@users.noreply.github.com>
Co-authored-by: EliasBerhe <eliastes123@gmail.com>
Co-authored-by: Foogabob <locker@dickinson.edu>
Co-authored-by: Foogabob <80643562+Foogabob@users.noreply.github.com>

---------

__Pull Request Description__

This pull request was orignially created on [FD2School-FarmData2](https://github.com/DickinsonCollege/FD2School-FarmData2).
Link to the original pull request: https://github.com/DickinsonCollege/FD2School-FarmData2/pull/173

Partially Addresses https://github.com/DickinsonCollege/FarmData2/issues/662

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
