### PR TITLE
Migrates: Tested Seeding Input Type Defaults (#178)

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.html
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.html
@@ -25,7 +25,7 @@
                 <input data-cy='direct-seedings' type='radio' name='typeOfSeeding' value='Direct Seedings'v-model='selectedSeedingType' :checked='selectedSeedingType == "Direct Seedings"' v-bind:disabled='submitInProgress'><label>Direct</label> 
             </legend>
             <div v-show='(selectedSeedingType=="")' style='text-align:center;font-size: medium;'>
-                <p>Please Select Tray Seeding or Direct Seeding<label style='color: #da4f3f'>*</label></p>
+                <p data-cy="seeding-type-prompt">Please Select Tray Seeding or Direct Seeding<label style='color: #da4f3f'>*</label></p>
             </div>
             <div v-show='(selectedSeedingType=="Tray Seedings")' style='padding: 12px; text-align:center; font-size: medium; margin-top: 45px;'> 
                 <dropdown-with-all data-cy="tray-area-selection" :selected-val='selectedArea' :dropdown-list='areaFilter' @selection-changed='setNewArea' style='width: 125px;' :disabled='submitInProgress'>Area:<label style='color: #da4f3f'>*</label></dropdown-with-all>

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.type.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.type.defaults.spec.js
@@ -1,0 +1,40 @@
+
+/**
+ * The seeding type selection section of the Seeding Input Log allows the user to select 
+ * the appropriate type of seeding, either tray seeding or direct seeding, for their log. 
+ * This spec tests that both of these options are enabled, that neither of these options 
+ * are selected by default, that a message is visible directing the user to select either 
+ * the Tray or Direct type, and that the form elements for Tray and Direct are not visible
+ * unless their respective option has been selected.
+ */
+
+describe("Test the seeding input type default values in the Seeding Input Log", () => {
+    beforeEach(() => {
+        cy.login("manager1", "farmdata2")
+        cy.visit("/farm/fd2-field-kit/seedingInput")
+    })
+      
+    it("Tests whether Tray and Direct elements are enabled", () => {
+        cy.get("[data-cy='tray-seedings']").should('be.enabled')
+        cy.get("[data-cy='direct-seedings']").should('be.enabled')
+    })
+
+    it("Tests that neither the Tray nor the Direct element is selected, and a message to prompt the selection of either element is visible", () => {
+        cy.get("[data-cy='tray-seedings']").should('not.be.selected')
+        cy.get("[data-cy='direct-seedings']").should('not.be.selected')
+        cy.get("[data-cy='seeding-type-prompt']").should('be.visible')
+    })
+
+    it("Tests that the form elements for Tray or Direct are not visible until clicked", () => {
+        //check form elements in tray seeding - should not be visible until tray radio button clicked
+        cy.get("[data-cy='tray-area-selection']").should('not.be.visible')
+        cy.get("[data-cy='num-cell-input']").should('not.be.visible')
+        cy.get("[data-cy='num-tray-input']").should('not.be.visible')
+        cy.get("[data-cy='num-seed-input']").should('not.be.visible')
+        ///check form elements in direct seeding - should not be visible until direct radio button clicked
+        cy.get("[data-cy='direct-area-selection']").should('not.be.visible')
+        cy.get("[data-cy='num-rowbed-input']").should('not.be.visible')
+        cy.get("[data-cy='unit-feet']").should('not.be.visible')
+        cy.get("[data-cy='num-feet-input']").should('not.be.visible')
+    })
+})


### PR DESCRIPTION
* created file to test seeding input type defaults

* Filled out before each

* Our team's test shows up in correct folder so we can run in Cypress

* Added test to check if the Tray element is enabled

* Added test to check if the Direct element is enabled

* tested that neither the tray nor the direct element is selected

* tested whether the message to prompt tray/direct element selection is visible

* Tested that the form elements for Tray and Direct are not visible

* Finished testing visibility of form elements - had to add one more

* Deleted unnecessary (duplicate) test file from field kit

* Adjusted the comment in the describe and added a descriptive comment at the top of the file.

* merged second and third individual test into one test

* changed data-cy attribute of message to prompt selection of tray or direct element

Co-authored-by: Alexandrialexie <brownale@dickinson.edu>
Co-authored-by: andrewscheiner53 <scheinea@dickinson.edu>

---------

__Pull Request Description__

Pull Request Description

This pull request was orignially created on [FD2School-FarmData2](https://github.com/DickinsonCollege/FD2School-FarmData2).
Link to the original pull request: https://github.com/DickinsonCollege/FD2School-FarmData2/pull/178

Partially Addresses https://github.com/DickinsonCollege/FarmData2/issues/662

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
