### PR TITLE
Fixed Total Bedft not Rounded in Seeding Report

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
@@ -568,7 +568,7 @@
                     tableData.map(h => {
                         sumBedFeet = sumBedFeet + parseFloat(h.data[5])
                     })
-                    return sumBedFeet
+                    return Math.round(sumBedFeet)
                 },
                 /**
                  * returns the total bed feet for Direct Seeding excluding the logs without labor data
@@ -581,7 +581,7 @@
                             sumBedFeet = sumBedFeet + parseFloat(h.data[5])
                         }
                     })
-                    return sumBedFeet
+                    return Math.round(sumBedFeet)
                 },
                 /**
                  * returns the total hours worked for direct seedings. Calculated by mulpitplying hours by workers for each log


### PR DESCRIPTION
__Pull Request Description__

Closes #657. This PR makes small changes to two computed methods in the Seeding Report page that concerns how the total bed feet is returned for the page to display in the direct seeding summary. Since logs can make the number a long decimal numbers, the return in these methods now rounds the value to the nearest integer to resolve this issue on the frontend.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
