### PR TITLE
Change default seeding type according to existing logs

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
@@ -18,7 +18,7 @@
                 <fieldset :disabled="rowBeingEdited" data-cy="filters-panel" class="center-block panel panel-default" style="width: 75%;">
                     <legend class="panel-heading" style="background-color: #d62a17; color: white;">Filters</legend>
                     <div :style=" !isMobile ? 'display: flex;width: 100%; padding: 7px' : 'display: grid; width: 100%'">
-                        <dropdown-with-all data-cy="seeding-type-dropdown" class="center-block" :dropdown-list='seedingTypeList' includes-all selected-val='All' @selection-changed='seedingChange' id="seedingType">Seeding Type:</dropdown-with-all>
+                        <dropdown-with-all data-cy="seeding-type-dropdown" class="center-block" :dropdown-list='seedingTypeList' includes-all :selected-val='getDefaultSeedingSelection()' @selection-changed='seedingChange' id="seedingType">Seeding Type:</dropdown-with-all>
                     
                         <dropdown-with-all data-cy="crop-dropdown" class="center-block" :dropdown-list='cropList' includes-all selected-val='All' @selection-changed='cropChange'>Crop:</dropdown-with-all>
 
@@ -38,7 +38,7 @@
                 <div style="display: flex; width: 100%;">
                     <fieldset data-cy="direct-summary" class="center-block panel panel-default" style="width: 50%;" v-if="!(selectedSeeding=='Tray Seedings')">
                         <legend class="panel-heading" style="background-color: #d62a17; color: white;">Direct Seeding Summary</legend>
-                        <div v-if="checkDirectSeedingSummaryTable()"></div>
+                        <div v-if="missingDirectSeedingLogs()"></div>
                         <div v-else>
                             <p style="margin-left: 5%;">Total Row Feet Planted: <b><span data-cy='direct-total-rowft'>{{ totalRowFeet }}</span></b></p>
                             <p style="margin-left: 5%;">Total Bed Feet Planted: <b><span data-cy='direct-total-bedft'>{{ totalBedFeet }}</span></b></p>
@@ -49,7 +49,7 @@
                     </fieldset>
                     <fieldset data-cy="tray-summary" class="center-block panel panel-default" style="width: 47%;" v-if="!(selectedSeeding=='Direct Seedings')">
                         <legend class="panel-heading" style="background-color: #d62a17; color: white;">Tray Seeding Summary</legend>
-                        <div v-if="checkTraySeedingSummaryTable()"></div>   
+                        <div v-if="missingTraySeedingLogs()"></div>   
                         <div v-else>
                             <p style="margin-left: 5%;">Total Number of Seeds Planted: <b><span data-cy='tray-total-seeds'>{{ traySeedsPlanted }}</span></b></p>
                             <p style="margin-left: 5%;">Total Number of Trays: <b><span data-cy='tray-total-trays'>{{ totalNumTrays }}</span></b></p>
@@ -370,21 +370,29 @@
                 enableFilters(){
                     this.rowBeingEdited = false
                 },
-                checkDirectSeedingSummaryTable(){
-                    if(this.getTableOneType == "Tray"){
-                        this.seedingChange("Tray Seedings")
+                missingDirectSeedingLogs(){
+                    if(!this.seedingTypeList.includes("Direct Seedings")){
+                       this.selectedSeeding = "Tray Seedings"
                         return true;
                     }else{
                         return false;
                     }
                 },
-                checkTraySeedingSummaryTable(){
-                    if(this.getTableOneType == "Direct"){
-                        this.seedingChange("Direct Seedings")
+                missingTraySeedingLogs(){
+                    if(!this.seedingTypeList.includes("Tray Seedings")){
+                       this.selectedSeeding = "Direct Seedings"
                         return true;
                     }else{
                         return false;
                     }
+                },
+                getDefaultSeedingSelection(){
+                    if(this.missingTraySeedingLogs()){
+                        return 'Direct Seedings'
+                    }else if(this.missingDirectSeedingLogs()){
+                        return 'Tray Seedings'
+                    }
+                    return 'All'
                 },
             },
             computed: {
@@ -913,6 +921,7 @@
                 if (window.screen.width < 900 || window.screen.height < 900) {
                     this.isMobile = true
                 }
+                
             }
         })
         Vue.config.devtools = true;

--- a/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
@@ -18,7 +18,7 @@
                 <fieldset :disabled="rowBeingEdited" data-cy="filters-panel" class="center-block panel panel-default" style="width: 75%;">
                     <legend class="panel-heading" style="background-color: #d62a17; color: white;">Filters</legend>
                     <div :style=" !isMobile ? 'display: flex;width: 100%; padding: 7px' : 'display: grid; width: 100%'">
-                        <dropdown-with-all data-cy="seeding-type-dropdown" class="center-block" :dropdown-list='seedingTypeList' includes-all selected-val='All' @selection-changed='seedingChange'>Seeding Type:</dropdown-with-all>
+                        <dropdown-with-all data-cy="seeding-type-dropdown" class="center-block" :dropdown-list='seedingTypeList' includes-all selected-val='All' @selection-changed='seedingChange' id="seedingType">Seeding Type:</dropdown-with-all>
                     
                         <dropdown-with-all data-cy="crop-dropdown" class="center-block" :dropdown-list='cropList' includes-all selected-val='All' @selection-changed='cropChange'>Crop:</dropdown-with-all>
 
@@ -38,9 +38,7 @@
                 <div style="display: flex; width: 100%;">
                     <fieldset data-cy="direct-summary" class="center-block panel panel-default" style="width: 50%;" v-if="!(selectedSeeding=='Tray Seedings')">
                         <legend class="panel-heading" style="background-color: #d62a17; color: white;">Direct Seeding Summary</legend>
-                        <div v-if="getTableOneType == 'Tray'">
-                            <p style="margin-left: 5%;" data-cy='direct-no-logs'>There are no Direct Seeding logs with these parameters</p>
-                        </div>
+                        <div v-if="checkDirectSeedingSummaryTable()"></div>
                         <div v-else>
                             <p style="margin-left: 5%;">Total Row Feet Planted: <b><span data-cy='direct-total-rowft'>{{ totalRowFeet }}</span></b></p>
                             <p style="margin-left: 5%;">Total Bed Feet Planted: <b><span data-cy='direct-total-bedft'>{{ totalBedFeet }}</span></b></p>
@@ -51,9 +49,7 @@
                     </fieldset>
                     <fieldset data-cy="tray-summary" class="center-block panel panel-default" style="width: 47%;" v-if="!(selectedSeeding=='Direct Seedings')">
                         <legend class="panel-heading" style="background-color: #d62a17; color: white;">Tray Seeding Summary</legend>
-                        <div v-if="getTableOneType == 'Direct'">
-                            <p style="margin-left: 5%;" data-cy='tray-no-logs'>There are no Tray Seeding logs with these parameters</p>
-                        </div>
+                        <div v-if="checkTraySeedingSummaryTable()"></div>   
                         <div v-else>
                             <p style="margin-left: 5%;">Total Number of Seeds Planted: <b><span data-cy='tray-total-seeds'>{{ traySeedsPlanted }}</span></b></p>
                             <p style="margin-left: 5%;">Total Number of Trays: <b><span data-cy='tray-total-trays'>{{ totalNumTrays }}</span></b></p>
@@ -373,6 +369,22 @@
                 },
                 enableFilters(){
                     this.rowBeingEdited = false
+                },
+                checkDirectSeedingSummaryTable(){
+                    if(this.getTableOneType == "Tray"){
+                        this.seedingChange("Tray Seedings")
+                        return true;
+                    }else{
+                        return false;
+                    }
+                },
+                checkTraySeedingSummaryTable(){
+                    if(this.getTableOneType == "Direct"){
+                        this.seedingChange("Direct Seedings")
+                        return true;
+                    }else{
+                        return false;
+                    }
                 },
             },
             computed: {

--- a/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
@@ -372,11 +372,11 @@
                 },
                 getDefaultSeedingSelection(){
                     if(!this.seedingTypeList.includes("Tray Seedings")){
-                       this.selectedSeeding = "Direct Seedings"
+                        this.selectedSeeding = "Direct Seedings"
                         return 'Direct Seedings'
                     }else if(!this.seedingTypeList.includes("Direct Seedings")){
-                       this.selectedSeeding = "Tray Seedings"
-                       return 'Tray Seedings'
+                        this.selectedSeeding = "Tray Seedings"
+                        return 'Tray Seedings'
                     }
                     return 'All'
                 },

--- a/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
@@ -38,7 +38,7 @@
                 <div style="display: flex; width: 100%;">
                     <fieldset data-cy="direct-summary" class="center-block panel panel-default" style="width: 50%;" v-if="!(selectedSeeding=='Tray Seedings')">
                         <legend class="panel-heading" style="background-color: #d62a17; color: white;">Direct Seeding Summary</legend>
-                        <div v-if="missingDirectSeedingLogs()"></div>
+                        <div v-if="getDefaultSeedingSelection === 'Direct Seedings'"></div>
                         <div v-else>
                             <p style="margin-left: 5%;">Total Row Feet Planted: <b><span data-cy='direct-total-rowft'>{{ totalRowFeet }}</span></b></p>
                             <p style="margin-left: 5%;">Total Bed Feet Planted: <b><span data-cy='direct-total-bedft'>{{ totalBedFeet }}</span></b></p>
@@ -49,7 +49,7 @@
                     </fieldset>
                     <fieldset data-cy="tray-summary" class="center-block panel panel-default" style="width: 47%;" v-if="!(selectedSeeding=='Direct Seedings')">
                         <legend class="panel-heading" style="background-color: #d62a17; color: white;">Tray Seeding Summary</legend>
-                        <div v-if="missingTraySeedingLogs()"></div>   
+                        <div v-if="getDefaultSeedingSelection === 'Tray Seedings'"></div>   
                         <div v-else>
                             <p style="margin-left: 5%;">Total Number of Seeds Planted: <b><span data-cy='tray-total-seeds'>{{ traySeedsPlanted }}</span></b></p>
                             <p style="margin-left: 5%;">Total Number of Trays: <b><span data-cy='tray-total-trays'>{{ totalNumTrays }}</span></b></p>
@@ -370,6 +370,7 @@
                 enableFilters(){
                     this.rowBeingEdited = false
                 },
+                /*
                 missingDirectSeedingLogs(){
                     if(!this.seedingTypeList.includes("Direct Seedings")){
                        this.selectedSeeding = "Tray Seedings"
@@ -386,11 +387,14 @@
                         return false;
                     }
                 },
+                */
                 getDefaultSeedingSelection(){
-                    if(this.missingTraySeedingLogs()){
+                    if(!this.seedingTypeList.includes("Tray Seedings")){
+                       this.selectedSeeding = "Direct Seedings"
                         return 'Direct Seedings'
-                    }else if(this.missingDirectSeedingLogs()){
-                        return 'Tray Seedings'
+                    }else if(!this.seedingTypeList.includes("Direct Seedings")){
+                       this.selectedSeeding = "Tray Seedings"
+                       return 'Tray Seedings'
                     }
                     return 'All'
                 },

--- a/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
@@ -18,7 +18,7 @@
                 <fieldset :disabled="rowBeingEdited" data-cy="filters-panel" class="center-block panel panel-default" style="width: 75%;">
                     <legend class="panel-heading" style="background-color: #d62a17; color: white;">Filters</legend>
                     <div :style=" !isMobile ? 'display: flex;width: 100%; padding: 7px' : 'display: grid; width: 100%'">
-                        <dropdown-with-all data-cy="seeding-type-dropdown" class="center-block" :dropdown-list='seedingTypeList' includes-all :selected-val='getDefaultSeedingSelection()' @selection-changed='seedingChange' id="seedingType">Seeding Type:</dropdown-with-all>
+                        <dropdown-with-all data-cy="seeding-type-dropdown" class="center-block" :dropdown-list='seedingTypeList' includes-all :selected-val='getDefaultSeedingSelection()' @selection-changed='seedingChange'>Seeding Type:</dropdown-with-all>
                     
                         <dropdown-with-all data-cy="crop-dropdown" class="center-block" :dropdown-list='cropList' includes-all selected-val='All' @selection-changed='cropChange'>Crop:</dropdown-with-all>
 
@@ -921,7 +921,6 @@
                 if (window.screen.width < 900 || window.screen.height < 900) {
                     this.isMobile = true
                 }
-                
             }
         })
         Vue.config.devtools = true;

--- a/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.html
@@ -370,24 +370,6 @@
                 enableFilters(){
                     this.rowBeingEdited = false
                 },
-                /*
-                missingDirectSeedingLogs(){
-                    if(!this.seedingTypeList.includes("Direct Seedings")){
-                       this.selectedSeeding = "Tray Seedings"
-                        return true;
-                    }else{
-                        return false;
-                    }
-                },
-                missingTraySeedingLogs(){
-                    if(!this.seedingTypeList.includes("Tray Seedings")){
-                       this.selectedSeeding = "Direct Seedings"
-                        return true;
-                    }else{
-                        return false;
-                    }
-                },
-                */
                 getDefaultSeedingSelection(){
                     if(!this.seedingTypeList.includes("Tray Seedings")){
                        this.selectedSeeding = "Direct Seedings"


### PR DESCRIPTION
__Pull Request Description__
This PR changes the `selected-val` of the Seeding Type Dropdown from 'All' to the `getDefaultSeedingSelection` function that returns the appropriate seeding type for the available logs.
Closes #658 
<Add description>

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
