### PR TITLE
Add Local flag to docker/buildimages.bash

### DIFF
--- a/docker/build-images.bash
+++ b/docker/build-images.bash
@@ -1,15 +1,26 @@
 #!/bin/bash
 
-# Build and push to DockerHub multi architecture images
-# for all of the containers used by FarmData2.
+# Build and optionally push to DockerHub multi architecture images
+# or single architecture local images for FarmData2.
 
-LOGGED_IN=$(cat ~/.docker/config.json 2> /dev/null | grep "index.docker.io" | wc -l | cut -f 8 -d ' ')
-if [ "$LOGGED_IN" == "0" ];
-then
-  echo "Please log into Docker Hub before building images."
-  echo "  Use: docker login"
-  echo "This allows multi architecture images to be pushed."
-  exit -1
+LOCAL_BUILD=0
+
+# Check for --local flag
+if [ "$1" == "--local" ]; then
+    LOCAL_BUILD=1
+    shift # Remove the --local argument
+fi
+
+# Check for Docker Hub login only if not a local build
+if [ "$LOCAL_BUILD" -eq 0 ]; then
+    LOGGED_IN=$(cat ~/.docker/config.json 2> /dev/null | grep "index.docker.io" | wc -l | cut -f 8 -d ' ')
+    if [ "$LOGGED_IN" == "0" ];
+    then
+      echo "Please log into Docker Hub before building images."
+      echo "  Use: docker login"
+      echo "This allows multi architecture images to be pushed."
+      exit -1
+    fi
 fi
 
 if [ $# -lt 1 ];
@@ -21,19 +32,21 @@ then
   exit -1
 fi
 
-# Create the builder if it doesn't exist.
-FD2_BUILDER=$(docker buildx ls | grep "fd2builder" | wc -l | cut -f 8 -d ' ')
-if [ "$FD2_BUILDER" == "0" ];
-then
-  echo "Making new builder for FarmData2 images."
-  docker buildx create --name fd2builder
+# Create the builder if it doesn't exist and if not a local build
+if [ "$LOCAL_BUILD" -eq 0 ]; then
+    FD2_BUILDER=$(docker buildx ls | grep "fd2builder" | wc -l | cut -f 8 -d ' ')
+    if [ "$FD2_BUILDER" == "0" ];
+    then
+      echo "Making new builder for FarmData2 images."
+      docker buildx create --name fd2builder
+    fi
+
+    # Switch to use the fd2builder.
+    echo "Using the fd2builder."
+    docker buildx use fd2builder
 fi
 
-# Switch to use the fd2builder.
-echo "Using the fd2bilder."
-docker buildx use fd2builder
-
-# Build and push each of the images to Docker Hub.
+# Build (and push) each of the images
 for IMAGE in "$@"
 do
   if [ ! -f $IMAGE/Dockerfile ] | [ ! -f $IMAGE/repo.txt ];
@@ -54,7 +67,14 @@ do
     TAG=$(cat repo.txt)
     REPO="farmdata2/$TAG"
     echo "  Performing docker build using tag $REPO ..."
-    docker buildx build --platform linux/amd64,linux/arm64 -t $REPO --push .
+
+    if [ "$LOCAL_BUILD" -eq 1 ]; then
+        # Local build for the architecture of the local machine
+        docker build -t $REPO .
+    else
+        # Multi architecture build and push
+        docker buildx build --platform linux/amd64,linux/arm64 -t $REPO --push .
+    fi
 
     if [ -f after.bash ];
     then


### PR DESCRIPTION
__Pull Request Description__

This PR aims to close/resolve #636 by adding a local flag to `docker/buildimages.bash`. Also made some slight changes (local builds use `build` insted of `buildx` for local builds and only multi-arch build use `fd2builder`)

__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
