### PR TITLE
add functionality to log cypress test to terminal

### DIFF
--- a/farmdata2/cypress/cypress.config.js
+++ b/farmdata2/cypress/cypress.config.js
@@ -17,6 +17,13 @@ module.exports = {
 
   e2e: {
     setupNodeEvents(on, config) {
+      on('task', {
+        log(message) {
+          console.log(message)
+
+          return null
+        },
+      })
       // implement node event listeners here
     },
     baseUrl: 'http://fd2_farmdata2',


### PR DESCRIPTION
__Pull Request Description__
close #686 
This add small feature to help log information such as request and response to terminal when using cypress test in headless mode .  To log information, use command `cy.task( "log", <your info>)` to print to terminal.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
