### PR TITLE
add user role/permission to module fd2_example

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_example/fd2_example.module
+++ b/farmdata2/farmdata2_modules/fd2_example/fd2_example.module
@@ -133,7 +133,22 @@ function fd2_example_preprocess_page() {
     // Define some useful variables in the JavaScript for page.
     // the @ symbol surpresses the warning when a user attempts to access a page without being logged in
     global $user;
-    @$cmd="var fd2UserID=".$user->uid."; var fd2UserName='".$user->name."';";
+
+
+   $account = user_load($user->uid);
+    // Map from roleID to role name
+    $roleMap = user_roles();
+    // Get the roles assigned to the user.
+    $roles = array();
+    foreach ($account->roles as $role => $roleName) {
+      $roles[] = $roleMap[$role];
+    }
+
+    @$cmd="var fd2UserID=".$user->uid."; var fd2UserName='".$user->name."'; ;";
     drupal_add_js($cmd,'inline');
+    $roleCMD = "var fd2Role = " . json_encode($roles) . ";"; // JSON encode roles array
+    drupal_add_js($roleCMD, 'inline');
+
+
   }
 };


### PR DESCRIPTION
__Pull Request Description__
close #447 
<Add description>
Add role/permission to login user, currently it must be  imported in each module the same way like uid and name property. There could be a way to refactor so that every modules can have a common file to import from. Image below is from sub tab `fd2_example`, and I have remove that `p` tag in the commit, but the usage is straightforward.
<img width="586" alt="Screenshot 2023-12-03 024447" src="https://github.com/DickinsonCollege/FarmData2/assets/86947901/4696e13a-36e6-4f7b-9b4b-aa7ed7dfeb58">

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
