### PR TITLE
Add  cypress logging functionality

### DIFF
--- a/farmdata2/cypress/cypress.config.js
+++ b/farmdata2/cypress/cypress.config.js
@@ -18,6 +18,13 @@ module.exports = {
   e2e: {
     setupNodeEvents(on, config) {
       // implement node event listeners here
+      on('task', {
+        log(message) {
+          console.log(message)
+
+          return null
+        },
+      })
     },
     baseUrl: 'http://fd2_farmdata2',
     specPattern: '**/*.spec.js',


### PR DESCRIPTION
__Pull Request Description__

close #686
This add small feature to help log information such as request and response to terminal when using cypress test in headless mode . To log information, use command cy.task( "log", <data>) to print to terminal.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
