### PR TITLE
revert changes to fd2-down.bash to work on MacOS too

### DIFF
--- a/docker/fd2-down.bash
+++ b/docker/fd2-down.bash
@@ -10,13 +10,29 @@ then
   exit -1
 fi
 
-if [ -z "$COMPOSE_PROFILES" ]; then
-    echo "Error: COMPOSE_PROFILES doesn't have profiles stored. Please run fd2-up.bash to bring FarmData2 containers up first."
-    exit 1
-fi
+# Env var was not being set on MacOS
+# So Revert this to the old approach.
 
+# if [ -z "$COMPOSE_PROFILES" ]; then
+#     echo "Error: COMPOSE_PROFILES doesn't have profiles stored. Please run fd2-up.bash to bring FarmData2 containers up first."
+#     exit 1
+# fi
 # I'm pretty sure since the COMPOSE_PROFILES utilize the environment variables, you can just run docker-compose down and that's it.
-docker-compose down
+#docker-compose down
+
+echo "Stopping Containers..."
+docker stop fd2_phpmyadmin
+docker stop fd2_farmdata2
+docker stop fd2_mariadb
+docker stop fd2_dev
+docker stop fd2_api
+
+echo "Deleting containers..."
+docker rm fd2_mariadb
+docker rm fd2_phpmyadmin --volumes  # remove /sessions volume created.
+docker rm fd2_farmdata2
+docker rm fd2_dev
+docker rm fd2_api
 
 #Unsets COMPOSE_PROFILES to prevent irregular edge cases. 
 unset COMPOSE_PROFILES

--- a/docker/fd2-up.bash
+++ b/docker/fd2-up.bash
@@ -297,6 +297,7 @@ COMPOSE_PROFILES=$(echo $profiles | tr ' ' ',')
 
 # Export the COMPOSE_PROFILES environment variable
 export COMPOSE_PROFILES
+
 # Delete any of the existing containers (except dev so that its writeable
 # layer - and thus any installed software or configuration - is preserved.)
 echo "Removing any stale containers..."


### PR DESCRIPTION
__Pull Request Description__

The `COMPOSE_PROFILE` environment variable was not working on MacOS.  So reverted the `fd2-down.bash` script to use the `stop` and `delete` commands instead.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
